### PR TITLE
Adjusted findings graphs by trimming after Oct 31st

### DIFF
--- a/model/RF_research_question_adj_plot.ipynb
+++ b/model/RF_research_question_adj_plot.ipynb
@@ -1,0 +1,1309 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Processing pipeline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.insert(1, '/Users/jakoliendenhollander/capstone/capstone')\n",
+    "import warnings\n",
+    "\n",
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline\n",
+    "import seaborn as sns\n",
+    "import datetime\n",
+    "\n",
+    "from datetime import timedelta\n",
+    "from sklearn import metrics\n",
+    "from sklearn.preprocessing import MinMaxScaler\n",
+    "from sklearn.compose import TransformedTargetRegressor\n",
+    "from sklearn.ensemble import RandomForestRegressor\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from yellowbrick.datasets import load_concrete\n",
+    "from yellowbrick.regressor import residuals_plot\n",
+    "from sklearn.inspection import plot_partial_dependence\n",
+    "\n",
+    "import tidy_functions.load_data\n",
+    "import tidy_functions.clean_data\n",
+    "import tidy_functions.merge_data_model\n",
+    "import tidy_functions.feature_engineering\n",
+    "\n",
+    "warnings.filterwarnings(action='ignore')\n",
+    "pd.set_option('display.max_columns', None) # To display all columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def mean_absolute_percentage_error(y_true, y_pred): \n",
+    "    y_true, y_pred = np.array(y_true), np.array(y_pred)\n",
+    "    return np.mean(np.abs((y_true - y_pred) / y_true)) * 100"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Read in data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Read in survey data completed.\n",
+      "Read in covid data completed.\n",
+      "Read in mask wearing requirements data completed.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Reading in survey data from csv into a dictionary of dataframes.\n",
+    "dfs_country = tidy_functions.load_data.load_survey_data(\"/Users/jakoliendenhollander/capstone/capstone/data/CMU_Global_data/Full_Survey_Data/country/smooth/\", \"country\")\n",
+    "\n",
+    "# Concatenating individuals dataframes from the dictionary into one dataframe for regions.\n",
+    "survey_data = pd.concat(dfs_country, ignore_index=True)\n",
+    "\n",
+    "# Corona stats\n",
+    "covid_cases = pd.read_csv(\"/Users/jakoliendenhollander/capstone/capstone/data/corona_stats_14days.csv\")\n",
+    "print('Read in covid data completed.')\n",
+    "\n",
+    "# Mask wearing requirements\n",
+    "mask_wearing_requirements = pd.read_csv(\"/Users/jakoliendenhollander/capstone/capstone/data/data-nbhtq.csv\")\n",
+    "print('Read in mask wearing requirements data completed.')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cleaning data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NaNs before update: 152923\n",
+      "NaNs after update: 0\n",
+      "Updated NaNs in wear_mask_all_time.\n",
+      "NaNs removed.\n",
+      "Step 1 of cleaning requirements completed.\n",
+      "Step 2 of cleaning requirements completed.\n",
+      "Step 3 of cleaning requirements completed.\n",
+      "Step 4 of cleaning requirements completed.\n",
+      "Step 5 of cleaning requirements completed.\n",
+      "Step 6 of cleaning requirements completed.\n",
+      "Creating dictionaries for hdi completed.\n",
+      "Creating dictionaries for hdi-levels completed.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Survey data\n",
+    "survey_data = tidy_functions.clean_data.delete_other_gender(survey_data)\n",
+    "survey_data = tidy_functions.clean_data.deal_with_NaNs_masks(survey_data)\n",
+    "\n",
+    "# Corona stats\n",
+    "covid_cases = tidy_functions.clean_data.deal_with_NaNs_corona_stats(covid_cases)\n",
+    "\n",
+    "# Mask wearing requirements\n",
+    "mask_wearing_requirements = tidy_functions.clean_data.prepare_mask_req(mask_wearing_requirements)\n",
+    "mask_wearing_requirements = tidy_functions.clean_data.dummies_mask_req(mask_wearing_requirements)\n",
+    "mask_wearing_requirements = tidy_functions.clean_data.dummies_public_mask_req(mask_wearing_requirements)\n",
+    "mask_wearing_requirements = tidy_functions.clean_data.dummies_indoors_mask_req(mask_wearing_requirements)\n",
+    "mask_wearing_requirements = tidy_functions.clean_data.dummies_transport_mask_req(mask_wearing_requirements)\n",
+    "mask_wearing_requirements = tidy_functions.clean_data.data_types_mask_req(mask_wearing_requirements)\n",
+    "\n",
+    "# HDI\n",
+    "hdi_data = tidy_functions.clean_data.rename_hdi_countries(\"/Users/jakoliendenhollander/capstone/capstone/data/\",\"hdro_statistical_data_tables_1_15_d1_d5.xlsx\")\n",
+    "dict_hdi = tidy_functions.clean_data.create_hdi_dict(hdi_data)\n",
+    "dict_hdi_levels = tidy_functions.clean_data.create_hdi_levels_dict(hdi_data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Merging data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Merging corona stats completed.\n",
+      "Merging mask wearing requirements completed.\n",
+      "Creating hdi list completed.\n",
+      "Creating hdi-level list completed.\n"
+     ]
+    }
+   ],
+   "source": [
+    "covid_merge = tidy_functions.merge_data_model.merge_corona_stats(survey_data,covid_cases)\n",
+    "requirements_merge = tidy_functions.merge_data_model.merge_mask_req(covid_merge,mask_wearing_requirements)\n",
+    "hdi_merge = tidy_functions.merge_data_model.create_hdi_columns(requirements_merge, dict_hdi, dict_hdi_levels)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Feature engineering"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Month column created.\n",
+      "Feature engineering completed.\n"
+     ]
+    }
+   ],
+   "source": [
+    "date_fixed = tidy_functions.feature_engineering.insert_month(hdi_merge)\n",
+    "requirement_date = tidy_functions.feature_engineering.add_requirement_by_date(date_fixed)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = requirement_date.copy()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data selection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = df[df[\"age_bucket\"]==\"overall\"]\n",
+    "df = df[df[\"gender\"]==\"overall\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "date = [\"date\"]\n",
+    "\n",
+    "columns_general = [\"iso_code\", \"hdi\", \"median_age\"]\n",
+    "\n",
+    "columns_general_no_iso = [\"hdi\", \"median_age\"]\n",
+    "\n",
+    "columns_social_distancing = [\"smoothed_pct_worked_outside_home_weighted\", \"smoothed_pct_grocery_outside_home_weighted\", \"smoothed_pct_ate_outside_home_weighted\", \n",
+    "                             \"smoothed_pct_attended_public_event_weighted\", \"smoothed_pct_used_public_transit_weighted\", \n",
+    "                             \"smoothed_pct_direct_contact_with_non_hh_weighted\", \"smoothed_pct_no_public_weighted\"]\n",
+    "\n",
+    "columns_mask_wearing = [\"smoothed_pct_wear_mask_all_time_weighted\", \"smoothed_pct_wear_mask_most_time_weighted\"]\n",
+    "\n",
+    "columns_mask_req = [\"cur_mask_recommended\", \"cur_mask_not_required\", \"cur_mask_not_required_recommended\", \"cur_mask_not_required_universal\", \n",
+    "                    \"cur_mask_required_part_country\", \"cur_mask_everywhere_in_public\", \"cur_mask_public_indoors\", \"cur_mask_public_transport\"]\n",
+    "\n",
+    "columns_past = [\"total_cases_per_million\",\"previous_7days\"]\n",
+    "\n",
+    "columns_pred = [\"next_14days\"]\n",
+    "\n",
+    "columns_interest = date + columns_general + columns_social_distancing + columns_mask_wearing + columns_mask_req + columns_past + columns_pred\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_select = df[columns_interest]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_time = df_select.copy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# convert columns from object to numeric\n",
+    "df_time.previous_7days = pd.to_numeric(df_time.previous_7days, errors='coerce')\n",
+    "df_time.next_14days = pd.to_numeric(df_time.next_14days, errors='coerce')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# sort data frame by time\n",
+    "df_time = df_time.sort_values('date')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Overall model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# drop date and iso code column\n",
+    "df_no_date = df_time.drop([\"iso_code\",\"date\"], axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define X and y\n",
+    "X = df_no_date.drop(\"next_14days\", axis=1)\n",
+    "y = df_no_date[\"next_14days\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(17016, 21) (4254, 21) (17016,) (4254,)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# divide the data into train and test data\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)\n",
+    "print(X_train.shape, X_test.shape, y_train.shape, y_test.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = RandomForestRegressor(criterion='mae')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define the target transform wrapper \n",
+    "wrapped_model = TransformedTargetRegressor(regressor=model,transformer=MinMaxScaler()) \n",
+    "# use the target transform wrapper \n",
+    "wrapped_model.fit(X_train, y_train) \n",
+    "yhat = wrapped_model.predict(X_test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mae: 107.49702310648813\n",
+      "mape: 3.7053800662706817\n"
+     ]
+    }
+   ],
+   "source": [
+    "# evaluate the model\n",
+    "print('mae:',metrics.mean_absolute_error(y_test, yhat))\n",
+    "print('mape:',mean_absolute_percentage_error(y_test, yhat))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Making predictions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def predict_cases(iso_code,date):\n",
+    "    what = df_time.loc[(df_time[\"iso_code\"]==iso_code) & (df_time[\"date\"]==date)]\n",
+    "    what = what[columns_interest]\n",
+    "    true_value = what[\"next_14days\"].values\n",
+    "    \n",
+    "    what.drop([\"iso_code\",\"date\",\"next_14days\"], axis=1, inplace=True)\n",
+    "    prediction = wrapped_model.predict(what)\n",
+    "    \n",
+    "    return str(true_value)[1:-1],str(prediction)[1:-1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Lebanon"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dates = []\n",
+    "true_values = [] \n",
+    "predicted_values = []\n",
+    "\n",
+    "for i in df_time.date.unique():\n",
+    "    i = str(i).split('T')[0]\n",
+    "    dates.append(i)\n",
+    "    true,prediction = predict_cases('LBN', i)\n",
+    "    true_values.append(true)\n",
+    "    predicted_values.append(prediction)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lebanese_data = pd.DataFrame([], columns=['date','true_value','predicted_value'])\n",
+    "lebanese_data['date'] = dates\n",
+    "lebanese_data['true_value'] = true_values\n",
+    "lebanese_data['predicted_value'] = predicted_values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lebanese_data['date'] = pd.to_datetime(lebanese_data.date, errors='coerce')\n",
+    "lebanese_data['true_value'] = pd.to_numeric(lebanese_data.true_value, errors='coerce')\n",
+    "lebanese_data['predicted_value'] = pd.to_numeric(lebanese_data.predicted_value, errors='coerce')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pivot_lebanese_data = lebanese_data.groupby(['date'])[['true_value','predicted_value']].mean()\n",
+    "pivot_lebanese_data = pivot_lebanese_data.stack().reset_index()\n",
+    "pivot_lebanese_data = pivot_lebanese_data.rename(columns={\"level_1\":\"value_type\",0: \"cases\"})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lebanese_mask = (pivot_lebanese_data.date < pd.to_datetime('2020-11-01'))\n",
+    "pivot_lebanese_data = pivot_lebanese_data.loc[lebanese_mask]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Germany"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dates = []\n",
+    "true_values = [] \n",
+    "predicted_values = []\n",
+    "\n",
+    "for i in df_time.date.unique():\n",
+    "    i = str(i).split('T')[0]\n",
+    "    dates.append(i)\n",
+    "    true,prediction = predict_cases('DEU', i)\n",
+    "    true_values.append(true)\n",
+    "    predicted_values.append(prediction)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "german_data = pd.DataFrame([], columns=['date','true_value','predicted_value'])\n",
+    "german_data['date'] = dates\n",
+    "german_data['true_value'] = true_values\n",
+    "german_data['predicted_value'] = predicted_values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "german_data['date'] = pd.to_datetime(german_data.date, errors='coerce')\n",
+    "german_data['true_value'] = pd.to_numeric(german_data.true_value, errors='coerce')\n",
+    "german_data['predicted_value'] = pd.to_numeric(german_data.predicted_value, errors='coerce')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pivot_german_data = german_data.groupby(['date'])[['true_value','predicted_value']].mean()\n",
+    "pivot_german_data = pivot_german_data.stack().reset_index()\n",
+    "pivot_german_data = pivot_german_data.rename(columns={\"level_1\":\"value_type\",0: \"cases\"})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "german_mask = (pivot_german_data.date < pd.to_datetime('2020-11-01'))\n",
+    "pivot_german_data = pivot_german_data.loc[german_mask]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Taiwan"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dates = []\n",
+    "true_values = [] \n",
+    "predicted_values = []\n",
+    "\n",
+    "for i in df_time.date.unique():\n",
+    "    i = str(i).split('T')[0]\n",
+    "    dates.append(i)\n",
+    "    true,prediction = predict_cases('TWN', i)\n",
+    "    true_values.append(true)\n",
+    "    predicted_values.append(prediction)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "taiwanese_data = pd.DataFrame([], columns=['date','true_value','predicted_value'])\n",
+    "taiwanese_data['date'] = dates\n",
+    "taiwanese_data['true_value'] = true_values\n",
+    "taiwanese_data['predicted_value'] = predicted_values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "taiwanese_data['date'] = pd.to_datetime(taiwanese_data.date, errors='coerce')\n",
+    "taiwanese_data['true_value'] = pd.to_numeric(taiwanese_data.true_value, errors='coerce')\n",
+    "taiwanese_data['predicted_value'] = pd.to_numeric(taiwanese_data.predicted_value, errors='coerce')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pivot_taiwanese_data = taiwanese_data.groupby(['date'])[['true_value','predicted_value']].mean()\n",
+    "pivot_taiwanese_data = pivot_taiwanese_data.stack().reset_index()\n",
+    "pivot_taiwanese_data = pivot_taiwanese_data.rename(columns={\"level_1\":\"value_type\",0: \"cases\"})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "taiwanese_mask = (pivot_taiwanese_data.date < pd.to_datetime('2020-11-01'))\n",
+    "pivot_taiwanese_data = pivot_taiwanese_data.loc[taiwanese_mask]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Mexico"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dates = []\n",
+    "true_values = [] \n",
+    "predicted_values = []\n",
+    "\n",
+    "for i in df_time.date.unique():\n",
+    "    i = str(i).split('T')[0]\n",
+    "    dates.append(i)\n",
+    "    true,prediction = predict_cases('MEX', i)\n",
+    "    true_values.append(true)\n",
+    "    predicted_values.append(prediction)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mexican_data = pd.DataFrame([], columns=['date','true_value','predicted_value'])\n",
+    "mexican_data['date'] = dates\n",
+    "mexican_data['true_value'] = true_values\n",
+    "mexican_data['predicted_value'] = predicted_values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mexican_data['date'] = pd.to_datetime(mexican_data.date, errors='coerce')\n",
+    "mexican_data['true_value'] = pd.to_numeric(mexican_data.true_value, errors='coerce')\n",
+    "mexican_data['predicted_value'] = pd.to_numeric(mexican_data.predicted_value, errors='coerce')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pivot_mexican_data = mexican_data.groupby(['date'])[['true_value','predicted_value']].mean()\n",
+    "pivot_mexican_data = pivot_mexican_data.stack().reset_index()\n",
+    "pivot_mexican_data = pivot_mexican_data.rename(columns={\"level_1\":\"value_type\",0: \"cases\"})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mexican_mask = (pivot_mexican_data.date < pd.to_datetime('2020-11-01'))\n",
+    "pivot_mexican_data = pivot_mexican_data.loc[mexican_mask]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABC4AAALICAYAAACw4rEDAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8vihELAAAACXBIWXMAAAsTAAALEwEAmpwYAAEAAElEQVR4nOzdd3gU1dvG8e+md3pvoYYSSugERbqIYOEVBAWli0pRREAQAVEDCEiVoqCIXUT8KQhSVEASuiAIUiRAkBJKAull5/1jyZqYwoJJNuX+XFcuszNnZp85kuyTZ86cYzIMw0BEREREREREJA9ysHcAIiIiIiIiIiKZUeFCRERERERERPIsFS5EREREREREJM9S4UJERERERERE8iwVLkREREREREQkz1LhQkRERERERETyLCd7ByAiuW/BggUsXLgQgNWrV1O/fv1M27Zv357z58/f9pyLFi2iY8eOhIWF0aFDh3T7TSYTLi4uFC9enFatWjFq1CjKli2b6fmWLl3KnDlzAKhatSobNmzIsN2aNWt45ZVXAOjSpQvz5s1Lsz91PMOHD2fEiBFp9icmJrJmzRo2bNjAn3/+yY0bN/Dy8qJWrVrcf//99OzZExcXlzTHjB8/nm+++QaA1157jSeffDLTmD766CNatGiR6XWKiIgUFD/++CPffPMNR48e5erVqzg5OVGxYkUCAwMZMGBAms/9fv36sXv37tue85VXXqF///4A+Pn5ZdjGyckJLy8vqlWrRu/evXn44Yet+zLKS7777jtq1aplff3HH3/w6KOPpmmzZcsWKlasmO69vv/+e1566SUAvL292bFjB25ubuna7dq1i6eeegqABg0a8OWXX2IymdK0SbmeRx99lOnTp/Paa6/xxRdfAPDII48wY8aMdOedMGECX3/9NQBPP/00EyZMyLBPRAoajbgQkVxhGAbx8fFcuHCBNWvW0KdPHyIjIzNtv2bNGuv3p0+fZs+ePbd9jw0bNhAcHGxzTOHh4fTu3ZvXXnuNnTt3cvXqVRITE7l+/Tq7du3i9ddf55FHHuHs2bOZnmP+/Plcv37d5vcUEREpaKKioqw3B7Zu3cqFCxdISEggJiaG48eP8+GHH/Lggw+yd+/eHHn/pKQkIiIi2L9/P2PHjuWDDz7Isv2/cwVbCigpUooGADdv3sz0xkpqhw4dSpPXZOall16iRIkSAHz77bccPHgwzf5jx45Zb5yULVuWkSNH2hy3SH6nwoWI2KRq1ar88ssvmX7de++96Y7p0aOHdf/WrVv59ttvefDBBwH4+++/+fjjjzN8r7179xIaGppm25dffmlTnG+++SZJSUm3bZeYmMiwYcM4fPgwAIGBgSxfvpzNmzfzySef0L17dwBOnTrF4MGDuXnzZobniYiI4J133rEpNhERkYJo/PjxbNq0CYDmzZuzdOlSNm3axGeffUa3bt0AS3FjxIgRREVFpTnW3d09y/yiZ8+e6d6vVatW1v0///wzmzdvZsqUKTg6OgKWUaCxsbGZxhsSEpLl68z8/fff6dramp/Mnj0701wiRZEiRRg/fjxgueHz5ptvYhiGdX9QUBBmsxmAV199FS8vL5veW6QgUOFCRGzi5ORE2bJlM/1ydXVNd4y7u7t1f4UKFahduzavvvqqdf+ff/6Z4Xul3M0wmUxUqlQJsAw/vXHjxm3jPHHiBJ988slt23311VfWokWHDh1Yvnw599xzD5UqVaJp06bMmjXLOsTzzJkzLF++PMtz/fHHH7d9TxERkYJm48aN1qJF+/bt+fDDD2nbti2VK1emcePGzJ4921q8uHbtGt9++22a400mU5b5haenZ7r3dHV1te4vV64clSpVok+fPrRu3RqwjIQ4ffp0uuMqVKgAwJ49e0hOTgYgOTnZOhIkZX9m1qxZYy0cVKlSBYB9+/Zx6tSp2/bT1atXWbBgwW3bPfTQQwQGBgJw8OBBa39t2bLFWjRp164dnTp1uu25RAoSFS5EJFelHg1RpkyZdPujo6Otwy6bNGlC3759AYiLi+N///tfludOeXZ04cKFXLt2Lcu233//vfX7sWPH4uCQ/tfhqFGjcHd3B9IODf33e5rNZqZNm5bl+4mIiBREqUccvPLKK9ZRD6mNHDmS8ePH8+mnn/J///d/ORZL6vfOaN6Jpk2bApbCxpEjRwDL/BYpIyGaNWuW6bkNw7A+plG+fHnGjBlj3bd69eos40rJTz755BNOnjx52+uYPHmydX6tWbNmERkZycyZMwHw8PBg0qRJtz2HSEGjwoWI2CQpKYmLFy9m+HX16tUMj4mNjbW2uXDhAseOHbN+2Lq4uPD444+nO+aHH34gJiYGgAcffJCuXbtaiwpfffVVljGmTMZ148YNZs+enWk7s9lsfW60fPny+Pr6ZtjOy8sLf39/AC5fvszff/+d6Xvu378/3V0kERGRgm7fvn0AVKxYkcqVK2fYpkqVKgwYMIAmTZqkKygYhpFpfnHp0qXbvr/ZbLbONbFjxw7A8tmeMiIitUqVKlknCE0ZvbBr1y4AypUrl+FknClCQkIICwsDoGvXrrRt2xYfHx8A1q5dS0JCQqbHpuQKSUlJvPHGG7e9Jl9fX5555hnAMh9Xnz59rI/QDh8+/LYjQ0QKIq0qIiI2OX36NPfdd1+G+2rXrp3hH+1r1qzJcDIqFxcXFi5cSI0aNdLtSxnZ4OTkRJcuXShevDjNmzcnJCSEY8eOcejQIRo0aJBhHI8++iihoaH89ttvfP311/Tu3ZtixYqlaxcREWEd+ZHRqI/USpcubf3+ypUrlC9fPs3+l19+mc2bNxMVFcXbb79Nx44dszyfiIhIQXH9+nXrXBKlSpVKsy8xMTHDGxspK4yliI2NzTS/8Pb2znBCz59//jnTFUY8PDx4/fXXMxz5AZZRF99//z0hISEMHTrUWrhIGY2RmdQjL7t164aLiwudOnXi66+/5tq1a2zZsoUHHnggw2NbtGhBfHw8P/zwA8HBwWzcuJH7778/y/cbOnQo33//PadPn7Y+iuLn58fTTz+d5XEiBZVGXIhIrktISOCNN95INy9EaGgo+/fvBywTb6UkNikTZULWwzFNJhOTJk3CwcEBwzCYNm1amkmtUqQ81wpkuD+1lGdZM1OyZEnrEqvh4eG8++67WbYXEREpKFI/Zpn6sxUsK2Dcd9996b5GjRqVI7EULVqUwYMHs3bt2gwnDE/RvHlzwDJSMjY21jpiJGV7RqKioqzzeFSrVo06deoAtucnYJnA1MPDA4AZM2YQFxeXZXsXFxemTJlifW0ymZg6dSpOTrrvLIWTChciYpOaNWvy559/ZviV2SMSTz75pLXNH3/8wa5du3jnnXfw8PDg7NmzDB06NM2s36nvZlSqVIlt27axbds26wc9WOamSHmUJCP+/v7WGcgPHjzI2rVr07UpWrSo9U5MRo9/pHbx4kXr9ylLlP1b3759qVmzJgArV65MtyKKiIhIQVSkSBHrZ/T58+fv6hweHh6Z5heZLZ/aqlUrtm7dyocffkjdunUBiIyMxGw2Z/q4SoqUkRWxsbF8/PHHREdHp9meke+//95aaKhZs6Y1P0lISLDOhfXrr79aHyXJSNmyZRk2bBhg6av33nsvyzgBWrZsaX0spHr16gQEBNz2GJGCSoULEckVjo6OFC1alK5du1qf9QwPD2fPnj2A5U5N6iLDp59+ypAhQxgyZAgvvviidXt0dDTr1q3L8r1efPFFihYtCpBhYuDs7Ey9evUAy9wVma1ucu3aNevKI6VKlcr0mVInJyfraimJiYl8+OGHWcYnIiJSULRo0QKwrJqR8pkJUL9+/TRFiOzk6upKhQoVaNWqFcuXL6dUqVIYhsGKFStYtGhRlsdWr16dkiVLAvD+++8DltGT1apVy/SY1DdWNm7caM1PUt+AMQzjtqMuBgwYYJ1XK+W9bZUywadIYaXChYjkutSPZ6TcwdixYweXL1+26fjbJQbFihWzDkWNj4/PsM0jjzxi/T4oKIjExMR0bd5++23r9h49emT5ni1btrQ+25rZe4qIiBQ0qVcJmT59eoaTVEZFReXY+xcvXjzNhJfvvvtumgJKRpo0aQJY5ryCrEdbnDx5kkOHDtkUy5o1a9I9MpOai4sLEydOBLjtoyIikpYekhIp5H777TeuX7+e4b7GjRtbv09ZVSQznp6eeHt7p9mWsqpIioSEBA4cOGBd1tTJycn6HqnvZnz44Ye0atUqzbkMw+D+++/nzJkz/Pbbbxw/fpxatWplGk/v3r356quv0s2jkaJnz558/fXXHDlyhODgYJ5++mmGDRtG1apVuXTpEitXruTHH38ELDOlDxo0KNP3SjF+/Hh++eWXLB9lERERKUg6depEp06d2LRpE3v27OHJJ59k2LBh1KpVixs3brBz504++uijTI9PWVUkM66urhlOtJ1a27ZteeSRR1i7di3Jycm8+uqrfP3115lO0Nm8eXM2btyY5nVmUucnb775Jo899li6Nk8//TQhISFcunSJbdu20a5du0zP16ZNG9q3b8/WrVuzvCYRSUuFC5FCLqtluVI/upHVqiIATz31lPUuQorMVhVJ8cwzz1CyZEmuXbtm/QCvUKECLVu2TNfWZDLRs2dPZs2aBViWRv33+6Xm4ODAa6+9Rp8+fTKcgNPFxYUlS5bw3HPP8fvvv7Nv3z6GDBmSrp2vry9LliyhSJEimb5XipTnV+fMmXPbtiIiIgXFjBkzcHFxYd26dRw6dIjnnnsuw3YVK1bk2WefTbMtq1VFADp06GDTxNcTJ05k586dXL58maNHj/Lxxx9nugLHv0dYZDbiIikpyXqzxcPDgy5dumTY7vHHH7cur/rVV19lWbgAmDBhAr/++qtGaIrcAT0qIiK5xsnJCU9PTxo0aMAbb7zByJEjAfjuu++sj2Q8+uijmT7H+X//9384OzsD8L///S/LNdMBAgIC0jwS8m+lS5fm888/JygoiHvuuYfixYvj5OREkSJFaNq0KRMnTuR///sfVatWtfkaUz+/KiIiUhh4enoyZ84cPvzwQ7p3746vry/u7u54eHhQtWpVevTowaJFi/jxxx8JDAzMkRh8fHyYOnWq9fW8efO4dOlShm39/Pysc2EVLVo00xGcP//8M1euXAHg/vvvx8vLK8N2nTp1sk7g/csvv9z20ddKlSpleLNERDJnMm63FmAO2rJlC2PGjOHAgQNptq9bt44lS5YQGhpKuXLl6NevH/369bPuT0hIYNasWaxbt46YmBjuvfdeJk6cSJkyZaxtIiMjCQoK4qeffsJsNtO5c2deeeWVNL9wLly4wBtvvEFISAiurq488sgjvPDCC7i4uOT8xYuIiEi2U24hIiJS8NjtUZH9+/fz8ssvp9u+fv16XnrpJQYMGMCECRMICQnhjTfewMvLi0cffRSAyZMns3XrVsaNG4eHhwdz5sxh6NChrFmzxvos24gRIwgLC2PKlCnExcUxc+ZMrly5wtKlSwFLgjJw4EDc3NyYOXMmFy5cYNasWcTFxfHaa6/lXkeIiIhItlBuISIiUkAZuSw+Pt5YtmyZUa9ePaNZs2ZGo0aNrPvMZrPRtm1bY+rUqWmOGT16tPHSSy8ZhmEYZ86cMWrXrm2sW7fOuv/06dOGn5+fsXHjRsMwDCM4ONioVauW8dtvv1nb7Ny506hVq5Zx+PBhwzAMY/Xq1UbdunWNCxcuWNt8+eWXRt26dY3w8PDsv3ARERHJEcotRERECrZcn+Ni27ZtLFu2jLFjx9K3b980+w4fPszff/9Nr1690myfPXu2dUK+lIlv2rZta93v6+tLzZo12b59OwDBwcGUKFGChg0bWtu0aNECLy8va5udO3dSt25dypYta23TsWNHkpKSCA4Ozr4LFhERkRyl3EJERKRgy/VHRerXr8+WLVvw8fFhwYIFafb9+eefACQnJ9O3b19+++03SpQowdChQ3nyyScBy8oGJUuWxMPDI82xFStWJDQ01NqmcuXKafY7ODhQoUIFa5vQ0NB0E+gVK1YMLy8vaxtbmc1moqOjcXZ2znRSQRERkbzOMAwSExPx9PTEwSH/zN9d0HIL5RUiIlIQZGdekeuFi9STXP3btWvXcHR05Nlnn+WJJ57g+eefZ/Pmzbz++usUK1aMrl27Eh0djaenZ7pjPT09rWtAZ9UmKioKgKioqNu2sVV0dDTHjx+/o2NERETyqlq1auHt7W3vMGxW0HIL5RUiIlKQZEdeYbfJOTOSlJREcnIyvXr1YtiwYQC0atWKsLAwFi5cSNeuXTEMI8O7D6m3G4aRYUXn39szO8+dVoNSlmesVatWjswafvLkSQBq1KiR7efOT9QP6oMU6gcL9YP6IEV29UNCQgLHjx+3fq4VBPkxt8jpvAL0s5OisPdDYb/+1NQXFoW9Hwr79aeWHX2RnXlFnipcpAzRbNOmTZrtgYGBzJgxg4SEBLy8vIiOjk53bExMjLWK4+XlRXh4eIZtUpYsy+o8ma3RnJmUJMXFxQVXV9c7OtYWKclOTpw7P1E/qA9SqB8s1A/qgxTZ3Q8F6fGE/Jhb5HReAfrZSVHY+6GwX39q6guLwt4Phf36U8vOvsiOvCJPPcBapUoVwFKZSS0pKcl6t8LX15crV64QFxeXpk1YWBhVq1YFLBNqnTt3Ls1+s9nM+fPn07QJCwtL0+b69etERUVZ24iIiEj+ptxCREQk/8tThYtmzZrh6urKhg0b0mz/+eefqV+/Pk5OTrRq1Yrk5GS2bt1q3R8aGsqJEydo1aoVYBkCGh4ezqFDh6xtdu3aRVRUlLVNy5YtOXz4sPXZVYDNmzfj7OxMs2bNcvIyRUREJJcotxAREcn/8tSjIl5eXjzzzDMsXLgQLy8vmjdvzvr169mzZw/Lli0DoHLlynTp0oVJkyYRFRWFj48Pc+bMwc/Pj44dOwKWxKFhw4YMHz6csWPHkpSUxIwZM2jbti3+/v4AdOvWjcWLFzN48GBGjRrF5cuXefvtt+nVqxelSpWyWx+IiIhI9lFuISIikv/lqcIFwPPPP4+3tzcff/wxy5cvx9fXlwULFqR5NjUoKIigoCBmzZqF2WwmMDCQiRMn4ujoCFieoVm8eDHTpk1j0qRJuLi40KFDByZMmGA9h7u7Ox988AGvv/46Y8aMwdvbmz59+jB69Ohcv2YRERHJOcotRERE8jeTYRiGvYPI7+Lj4zl8+DD+/v45MpHL0aNHAahTp062nzs/UT+oD1KoHyzUD+qDFNnVDzn9eSa2yY3/D/rZsSjs/VDYrz819YVFYe+Hwn79qWVHX2Tn51memuNCRERERERERCQ1FS5EREREREREJM9S4UJERERERERE8iwVLkREREREREQkz1LhQkRERERERETyrDsqXCQmJlq/37ZtG5988gkXL17M9qBERESkcFBuISIiIrdjU+Hi8uXL9OrVi3fffReADz/8kGeeeYZp06bRrVs3jh07lqNBioiISMGi3EJERERsZVPhYs6cOZw5c4YGDRoAsHz5clq0aME333xDtWrVmD9/fo4GKXmTYRj2DkFEpFCLjkkgISHJ3mHcFeUWkhHlFiIikhGbChc7duzgpZdeol27dvzxxx+Eh4fTr18/6tSpw8CBA9m3b19Oxyl5zObNm5k8ebK9w8g2a9aswc/Pj2vXrtk7FBERm/yyO5SS97xNve7vciM6wd7h3DHlFvJvyi1ERCQzTrY0ioyMpEqVKgDs3LkTR0dHWrRoAYCPjw8JCfkvYZL/ZuXKlXh4eNg7DBGRQskwDIZ9cpC4GaM5eTWC85Hn8fF0sXdYd0S5hfybcgsREcmMTSMuypQpw19//QXA1q1b8ff3x8vLC4Ddu3dTtmzZnItQRERE0ti2/xzH7g0ET3eoXA730kXsHdIdU24hIiIitrKpcNG+fXtmz57NoEGD2L9/Pw899BAAb775Ju+//z7dunXL0SAlb+nXrx+7d+/m559/xs/Pj/Hjx9OjRw/eeustmjZtSu/evQkLC8PPz48NGzakOfbhhx9m/Pjx1tcxMTFMmzaNwMBAGjRoQL9+/fjjjz9sjiUmJoaAgACWLl2aZvuJEyfw8/MjODgYgEOHDjFkyBCaNm2Kv78/999/P59//nmW1/jMM8+k2fbhhx/i5+eXZtv3339P9+7dqV+/Ph07dmTVqlU2xy4icrde2BkO5UsB4JsQTWXH/DfPhXILSU25xT+UW4iIpGfToyIvv/wyCQkJ7N69m6effpo+ffoAEBISwmOPPcawYcNyNMiC6ov1h3ltwU/cjI7Psl1SkiUhdXJal+0xeHu68vqIdjze1d/mYyZPnszLL7+Mm5sb48aNY8uWLXz33Xe4urqyYMEC4uOzvp4UhmHw7LPP8ueffzJ69GhKlSrFxx9/TL9+/fjmm2+oXLnybc/h4eFB+/bt2bBhQ5pkYP369ZQqVYoWLVrw999/89RTT3Hfffcxb948kpKS+Oyzz5g8eTKNGjWidu3aNl97at988w3jx4/nySefZNy4cfz2228EBQURHx/P4MGD7+qcIiK389vZCH6rVcf6+n1/VxzC7RjQXVJukTOUWyi3EBEpiGwqXDg7OzNlypR027/55hucnJy4evUqJUqUyO7YCry3V/zK8dCrdo3hQngUsz7YeUfJRY0aNfDy8sLDw4NGjRqxfft2kpKSmDBhAvXr1wcgLCzstufZsWMHISEhfPDBBwQGBgJw77338uCDD7J48WKCgoJsiqdbt24MGzaMs2fPWhOSDRs28MADD+Dg4MCJEydo1KgRs2bNwtnZGYCGDRvSokUL9u7de1fJhdlsZs6cOXTv3p3XXnsNgHvuuQeTycS7777LE088oed0RSRHDN15DSpXA6DOtUt0KFmGo/mwcKHcImcot1BuISJSENlUuFi2bBlDhw5Nf7CTEz/88AOvv/66ddic2O7lga3v8K6ITf+77oi3pysvDwzMlnNVr179jtrv2rULd3d3mjVrZr1GsHxIb9261ebz3HPPPRQtWpQNGzYwdOhQjh07xl9//cWMGTMAuO+++7jvvvuIj4/n2LFjhIaG8vvvvwPc9eRvp0+f5vLly7Rt2zZN7G3atGH+/PkcOnSIli1b3tW5RUQyE34jjr3Fb839kJzMigBP+wb0Hyi3yBnKLZRbiIgURDZ9Ws2ZMwd3d3f69etn3RYZGcnUqVNZv3491apVy7EAC7LHu/rbdDfi6NGjANSpU+c2Le3Hw8Pjju8CREREEBsbi79/+j5IuXthC2dnZ+6//35rcvHDDz9QqVIlGjRoAEBycjLTp0/niy++IDExkcqVK9O0aVPg7teLj4iIAOCll17ipZdeSrc/PDwf3v4UkTzv5U1nMMpZnoevfPkiLe+tYOeI7p5yi5yh3EK5hYhIQWRT4WL48OG89dZbuLm50bNnT37++WcmTZrE9evXGTp0KMOHD8/pOCWfMZlMgGXYY2oxMTHW7729vSlRokS6ya/uRrdu3fjiiy8ICwtjw4YNPPjgg9Z9ixcv5ssvv2TGjBncd999eHh4EBsby+rVq7M85+1iB3jttdesSUxqFStW/C+XIyKSTnKymS+i3ayvx9Z0t2M0/51yC7lTyi2UW4hI4WVz4QIsEydt3LiRHTt24Ofnx5IlS6hXr16OBih5k4ND1gvSpCxpd/nyZeu2S5cuERYWRpMmTQBo0qQJH3zwAR4eHmmGgr711lsYhmF9ptUWzZo1o2zZsrz//vuEhobSvXt3677ffvsNf39/HnjgAeu27du3A5nfFfHy8uLvv/9Os23fvn3W76tVq0bRokW5dOlSmji3b9/OypUrmTx5MsWKFbM5fhGR21m29RRx1WoA4BoVxbBWxe0c0X+j3EL+TbmFcgsRkczY/GBjSoKxcOFC2rZty6JFi3B0dMyxwCRv8/Hx4ejRo+zatYu4uLh0+4sUKULDhg1ZsWIF5cqVw9HRkYULF+Lj42Nt065dO+rXr2+9s1auXDl+/PFHPvnkE6ZOnXpH8ZhMJrp27crKlSvx8/OjRo0a1n3169fnvffe4+OPP6ZWrVr8/vvvLFq0CJPJlGHsYHmedMqUKSxYsIBmzZqxceNGDh8+bN3v5OTEiBEjmD59OgCtWrUiLCyM2bNn4+vrq7siIpLt3vojCppZ7jg/6haHo8nLzhH9d8otJDXlFsotREQyk2nhYv369em2VatWjYYNG7Jjxw4++eQTSpYsad3XtWvXnIlQ8qT+/fvz4osvMnjwYJo1a5Zhm6CgIKZMmcKYMWMoVaoUQ4cOZefOndb9jo6OLF++nFmzZvH2228TFRVFlSpVCAoKokePHnccU/fu3VmxYgXdunVLs33o0KGEh4ezcOFC4uPj8fX1ZdKkSXz//fccOHAgw3P17NmT06dP8/HHH7NixQo6duzIhAkTGDt2rLVN3759cXNz48MPP2TFihUULVqULl268OKLL1qHs4qIZIeth/4mrLZlbgsMg7ea5c/RFsotJCvKLZRbiIhkxmRkMp6tdu3amEymNMPd/v069faUSZ4Ko/j4eA4fPoy/vz+urq7Zfv78MIFWblA/qA9SqB8s1A+Fpw/qfnCMo36W5RUDoq+xv1PawkV29UNOf54pt7BNTv9/gMLzs3M7hb0fCvv1p6a+sCjs/VDYrz+17OiL7Pw8y3TExUcfffSfTizyX5nN5jSTWCUnJwOkWSLMZDJpWLGIFGi7w25wtOqtZ/WTk/mgaf59RES5hdibcgsRkfwp08JF8+bNc/zNt2zZwpgxYzIdUnft2jW6du3Kk08+yYgRI6zbExISmDVrFuvWrSMmJoZ7772XiRMnUqZMGWubyMhIgoKC+OmnnzCbzXTu3JlXXnnFOrETwIULF3jjjTcICQnB1dWVRx55hBdeeAEXF5ecu2ix2YQJE/jmm2+ybNO8eXNWrVqVSxGJiOS+gfuioJTlGf4ml8/TsFhlO0d095RbiL0ptxARyZ9snpwzLi6OTz/9lG3btnHp0iXmz5/Ptm3bCAgIoHHjxnf8xvv37+fll1/Oss2bb77J9evX022fPHkyW7duZdy4cXh4eDBnzhyGDh3KmjVrrBXyESNGEBYWxpQpU4iLi2PmzJlcuXLFujxWQkICAwcOxM3NjZkzZ3LhwgVmzZpFXFwcr7322h1fj2S/4cOH8+STT1pfh4aGAuDr62vd5unpmctRiYjknk/OxnOkVHnLi9h4lrcsatd4sptyC8ltyi1ERPInmwoXERER9OvXj5MnT1KlShXOnDlDQkIC27dvZ/78+Xz00Uc0bNjQpjdMSEhg5cqVzJs3Dw8PDxITEzNst3XrVnbs2JHuWZizZ8+ydu1aZs+ebZ20q3bt2nTp0oUtW7bQuXNnQkJC2LVrF19++aU1rrJly9K/f3+OHDlCvXr1+O677zh79ixbtmyhbNmyALi6ujJlyhSee+65NJODiX1UrFgxzQzaTk6Wf6565kxECoMLCTDktAmcLa+bnThKww6N7BpTdlJuIfag3EJEJH/KesHsW+bMmUN4eDhr1qzh+++/t06itXDhQqpXr86iRYtsfsNt27axbNkyxo4dS9++fTNsc/PmTaZMmcL48ePTDa0MCQkBoG3bttZtvr6+1KxZ07p+dnBwMCVKlEiT8LRo0QIvLy9rm507d1K3bl1rYgHQsWNHkpKSCA4Otvl6REREspthQO/DicQ6Wz4DTYdP8kW3KnaOKnsptxARERFb2TTiYsuWLYwcOZI6depYJzEC8PLyYtCgQbzxxhs2v2H9+vXZsmULPj4+LFiwIMM2M2bMoEaNGjz66KO8+eabafadPn2akiVL4uHhkWZ7xYoVrcP9Tp8+TeXKaZ8BdnBwoEKFCtY2oaGhaYYFAhQrVgwvLy9rmzt18uRJHBxsqgXdkdjYWIBCO7t6CvWD+iCF+sFC/VBw+2Bzghfb4ipZXtyIpue5Q8TdrMPRoxczbJ9d/ZB60sKcptzi9nIqr4CC+7Nzpwp7PxT2609NfWFR2PuhsF9/atnRF9mZV9hUuLh582aaYXWp+fj4EB0dbfMbpp7kKiPBwcGsW7eO//3vfxnuj46OzvDZQ09PTy5evHjbNlFRUQBERUXdto2IiEhuSzTgzevF4dagANevNzJqcDX7BpUDlFuIiIiIrWwqXPj6+vLTTz/Rpk2bdPuCg4PT3V24W7GxsUyaNIkRI0ZQqVKlDNsYhoHJZMpyu2EYGd6h+Pf2zM5zt3c3atSokSPrrWs9YQv1g/oghfrBQv1QMPvgrROxXHJxt7w4Fca0VmUIbNEoy2Oyqx9S1lvPDcotbi+n8goomD87d6Ow90Nhv/7U1BcWhb0fCvv1p5YdfZGdeYVNhYsnnniCqVOn4ujoSMeOHTGZTJw/f549e/bw8ccfM27cuGwJ5p133sHb25u+ffumWU/bbDaTlJSEk5MTXl5eGd6FiYmJwdvbG7AMMw0PD8+wTcqSZVmdJ/WyZiIiIrnlWryZKWeBW3WLpkcP89Ibne0aU05RbiEiIiK2sqlw0bt3b86cOcPKlSv55JNPMAyDUaNGAZbEI/WyUv/F5s2bOX/+PPXr10+z/d133+Xdd9/lzz//xNfXlytXrhAXF4ebm5u1TVhYGE2aNAEsd3H279+f5hxms5nz58/TvXt3a5uwsLA0ba5fv05UVBRVq1bNluuRvCWzO2oiInlFlx/+JrG05fEJ18Mn+H70PTk2x4G9KbeQgkC5hYhI7rA5Gxo3bhwbN25kypQpvPDCC0yaNIl169YxadKkbAtm8eLFrF69Os2Xh4cHvXr1YvXq1QC0atWK5ORktm7daj0uNDSUEydO0KpVK2ub8PBwDh06ZG2za9cuoqKirG1atmzJ4cOHrc+ugiW5cXZ2plmzZtl2TZI9xo8fz8iRI62v/fz8WL58uU3H3rhxg5deeokjR4785zjat2/P66+//p/Pcyd27dqFn58fv//+e66+r4jkroXB59lTsoLlRUIi7zdwo0zJgn2XXrmF2JNyCz9OnjyZq+8rInK3bBpxkaJSpUo89thjXLt2jWLFilnXvs4ufn5+6bY5OjpSunRp652SypUr06VLFyZNmkRUVBQ+Pj7MmTMHPz8/OnbsCFgSh4YNGzJ8+HDGjh1LUlISM2bMoG3btvj7+wPQrVs3Fi9ezODBgxk1ahSXL1/m7bffplevXpQqVSpbr0uy3xdffEH58uVtanv06FG+//57+vfvn7NBiYjcpfNXo3nxvDOUt9y5bR9+lr49q9s5qtyh3ELyCuUWIiJ5l83ZwcmTJ5k1axbBwcEkJiby1Vdf8dFHH1GnTp1c/6UdFBREUFAQs2bNwmw2ExgYyMSJE3F0dAQsE2MtXryYadOmMWnSJFxcXOjQoQMTJkywnsPd3Z0PPviA119/nTFjxuDt7U2fPn0YPXp0rl6L3J1GjRrZOwQRkWwRZ4b7gqNJKl8aAM+r11n3SOF4rEC5heQlyi1ERPIumx4VOX78OL169eKPP/7g4YcfxjAMAJycnJgxY0amy4vdzogRIzhw4ECWbfbu3cuIESPSbPPw8GDatGns3r2bvXv3Mn/+/HRLoZUoUYK5c+dy4MABdu3axVtvvZVuYqwqVaqwfPlyDh48yI4dOxg3bhzOzs53dS2FjZ+fH59//jnPPvssDRs2pH379nz88cfW/WFhYfj5+bFy5Urat29P69atrc8G//rrr/Ts2ZMGDRrQpk0b5s2bR3JysvXYpKQkZs2aRevWrWncuDFBQUFp9qe8f+rhnMeOHWPw4ME0btyYwMBAXnnlFSIiIti1axdPPfUUAI899hjjx4+3HvPRRx/RuXNn/P39efDBB1m/fn2a9wgPD2fkyJE0adKEe++9l7Vr195xP3Xo0IHXXnstzbbIyEj8/f2tQ5T/+usvRo4cScuWLfH396d9+/YsWrTI+nP2b/PmzaNbt25ptm3evBk/P780z1bfrp9FxP5ik6HL78mcKm4pWpCUzMf1nHBzLpjzWqSm3EL+TbmFbXIitxg/frxyCxHJ02zKjGbPno2vry8bN27ktddes/7Se/PNN+ncuTOrVq3K0SAlb5o1axYeHh4sWLCATp06MW3aNL788ss0bebNm8eYMWN4+eWX8ff3Jzg4mCFDhlCxYkUWLlzIoEGD+OCDD3jjjTesx7z11lusWrWKIUOGMGfOHI4dO8YPP/yQaRznz5/niSeeICoqipkzZ/Lqq6/y66+/8tJLL1GvXj3rh3tQUBDPPfccAAsXLmTGjBl07dqVJUuWEBgYyOjRo63vk5yczKBBgzh8+DDTpk1j/PjxzJ8/n0uXLt1RHz344IP8+OOPaT7UN23aBEDnzp2Jjo7mqaeeIiIighkzZrB06VJatGjB/Pnz+emnn+7ovVKzpZ9FxP7euwy/RFvu6JOQSOf9u3mkmrd9g8olyi0kI8otbk+5hYgURjY9KrJnzx6mTZuGu7t7uqpqjx49NATyLn1xBV47CzdvU6hOSqoBgNOe7I/B2xFerwyPl7zzY6tVq8bs2bMBaNOmDRcuXGDJkiX06tXL2uaRRx6ha9eu1tdz586lYcOGvPPOO9bjihQpwiuvvMKgQYPw8vLi888/54UXXrAOE27VqhXt2rXLNI6VK1fi6OjI+++/b73z5erqysyZM0lMTKRGDUv/1axZk8qVK3Pjxg2WLVvG4MGDeeGFFwC45557iI6OZvbs2TzwwAP8/PPP/Pnnn3zxxRfWoaO+vr706NHjjvqoe/fuLF26lN27d1snb/vhhx9o06YNPj4+HD58mMqVKzN37lyKFy9uvd7NmzezZ88e2rdvf0fvl+J2/VyxYsW7Oq+IZK8d15OBW4WLpatZ8FYnu8aTm5Rb5AzlFsotlFuISEFkU+HCMAxcXV0z3JeYmJjpsDPJ2tvn4XicLS1vDTFNzP4YLiTCrPN3l1ykThrAMnRx48aNaWZTr179n8nlYmNjOXToEC+++CJJSUnW7W3atMFsNrNr1y5KlixJcnIybdq0se53dXXlvvvuY+/evRnGceDAAZo1a5ZmuG6HDh3o0KFDhu1/++034uPjadu2bbo4vv76a86dO8f+/fspUqRImudd69WrR4UKFW7TK2nVrFmTWrVq8cMPP9CqVSvrENOZM2cC4O/vz6effkpiYiInT54kNDSUP/74g6SkJBISEu7ovVLY0s9KLkTyhpBLseBq+d31aAUXalW9i1/G+ZRyi5yh3MJCuYVyCxEpWGwqXNSvX59PPvkkw1/W//vf/6yzacudebmCrXdFLFmFk1P2PyPr7WiJ426ULl06zeuUqn5ERIT1g75EiRLW/Tdu3MBsNjN79mzr3ZTUwsPDcXFxAaBYsWJp9pUsmXn2ExkZSe3atW2OOyIiAoDevXtnuD88PJwbN26kiwG4q1nhu3fvzgcffMDkyZPZtGkTzs7Oae7yLFmyhPfff5+bN29SoUIFAgICcHJyuuuk3ZZ+FhH7M5sNzmP5nce1SCYOaGXfgHKZcoucodwiLeUWyi1EpGCwqXDx3HPPMWjQIHr06EH79u0xmUxs3LiRRYsW8fPPP9u85rWk9XhJ2+5GHD1qWWO7Tp06ORzRnbl+/Xqa11evXgUsSUZGFX1PT08Ann322QwT1dKlS3P8+HEArl27lmZStJSEICNeXl5cu3YtzbaEhASCg4MJCAhI197b2/L8+KJFi9JNvAZQtWpVihYtar2e1LKKIzMPPvggc+bMYe/evWzYsIEOHTrg7u4OwNq1a5k7dy6TJ0+mW7du1thShn5mxGQyYTab02yLjo62fm9LP4uI/a377TxmV8sdSp/oKJrUu8u/9PIp5RY5Q7lFWsotlFuISMFg0+ScLVu2ZP78+URGRlpnJF62bBlHjhxh9uzZWf4ilILr559/TvN6y5YtVKtWLdMPLy8vL2rXrs25c+eoX7++9cvZ2Zk5c+Zw8eJFAgICcHFx4ccff7Qel5SUxK+//pppHI0bN2bPnj1pPmCDg4MZOnQoV69etS5ll6Jhw4Y4Oztz9erVNHGcOHGCRYsWAdCiRQtu3rxJcHCw9bjTp09z9uxZm/snRYUKFWjUqBHfffcdISEhdO/e3brvwIEDlC1blj59+lgTiyNHjnDt2rVM74p4eHhw9erVNAnGvn37rN/b0s8iYn/vbj1t/T6gmIsdI7EP5RaSEeUWtsnu3MLT01O5hYjkaTaNuIB/nusLDQ3l2rVrFClShGrVqmEymXIyPsnDtm/fzuuvv0779u35+eef2bRpE3Pnzs3ymJEjR/L888/j5eVFp06duH79OnPnzsXBwYFatWrh7u7OoEGDeO+993B1daVu3bp89tlnXLlyJcM7GABPP/0033zzDc888wwDBw4kJiaGWbNm0blzZ6pWrWq9Q/PLL7/g4eFB9erV6devH9OnTycyMpIGDRpw7Ngx3nnnHTp06ICXlxetW7emWbNmvPzyy4wZMwYPDw/mzp1710vade/enTfffBNvb28CAwOt2+vXr8/nn3/OwoULad68OadOnWLRokWYTCbi4jJ+SLlx48Z8//33TJ06la5duxISEsLmzZvvqJ9FxL4ibsSy5fQNuPXr4IFa6YePFwbKLeTflFvYLjtzizZt2rBq1SrlFiKSZ9lUuOjduzedO3emU6dO+Pr64uvrm8NhSX4wePBgjh49ynPPPUflypV555136NKlS5bHdOjQgXfffZdFixaxZs0avLy8CAwMZMyYMdYhjqNGjcLNzY1PP/2UGzdu0LlzZ3r16sUvv/yS4TkrVarExx9/zMyZM3nxxRfx9vamS5cuvPjii4BlEquHH36YpUuXcvjwYZYsWcLLL79M8eLF+fLLL5k/fz6lS5fm6aefZvjw4YBlyOTixYt56623ePPNN3FycmLgwIHW5cbu1AMPPMBbb73F/fffnyZB6dGjB6dPn+bzzz/n/fffp0KFCgwaNIhTp06ludORWuPGjXnxxRf5+OOPWbt2La1atWL69OkMGTLkjvpZROznk+9+J7FEUevr+kVsvo9QYCi3kIwot7BdduYWbdq0UW4hInmaybBhlp7Bgweze/du6/JPnTt3pmPHjnnuuUh7iY+P5/Dhw/j7+2c6Q/p/cfToUSBvPYfq5+fH2LFjGTRoUK69Z17sh9ymPrBQP1ioH/JnHxiGQaNHl3Coc3to5AfAiQCo8R/y/uzqh5z+PEtNuUXmcuP/Q1782VFukfsK+/Wnpr6wKOz9UNivP7Xs6Ivs/Dyz6RbP+++/T2xsLDt27GDr1q18/vnnLFq0iPLly9OpUyc6duxIs2bN/lMgIvmJ2WxON4nVv5lMpnTPwIqI7Pn9PIf+vAT9LCsjOJvA183OQdmBcguRtJRbiIhkzuaxqe7u7nTq1IlOnTphGAb79+9n7ty5rFy5ko8++shakREpDBYtWsTChQuzbFOhQgW2bt2aSxGJSH6x7Mt94OAApSzzWlR3A6dCOqWDcguRfyi3EBHJ3B09VHv8+HGCg4MJCQlhz549REVFUbx4cc38XQj9+eef9g7Brnr16kXbtm2zbJOybryISIobUXF8tv4wlCwKTpa7prUK4WiL1JRbSArlFsotREQyY1Ph4qWXXiIkJIRr167h4uJCkyZNGDZsGK1bt9bzP1IolSlTJtOZyEVEMvPZusPExCZCzRLWbbUK6Zx2yi1E0lJuISKSOZsKF+vWrQOgQYMGDB48mHvuuQcPD48cDUxERKQgMQyDxZ/vsbwo80/hwq+QFi6UW4iIiIitbCpcrF69ml9//ZUdO3YwevRoABo2bEhgYCCtW7emQYMGODg45GigIiIi+dnPu0M5eOwSACXqVObqre2F9VER5RYiIiJiK5sKF/7+/vj7+/PMM88QHR3Nrl272LlzJxs2bGDhwoV4e3uze/funI5VREQk35rzYbDlG0dHEuvXBMABqFdIBxkotxARERFb3fGtDCcnJ5ycnHBwcCApKQnDMHRHREREJAt/nr7C9z8fB6Bo20bccHAGoHtxKOFsz8jyBuUWIiIikhWbRlycOnWK7du3s337dvbu3UtCQgIVKlSgQ4cOTJ06laZNm+Z0nCIiIvnWvI9CrN8Xe+heIm59/2whnodPuYWIiIjYyqbCxYMPPghA3bp1GTp0KB07dsTPzy9HAxMRESkIzpyPYMWaAwC4+pbltFdRAKq5Qqei9ovL3pRbiIiIiK1sKly8+uqrdOzYkbJly+Z0PCIiIgXKhLlbiE9IBqD2wAc4eGv7M2XBwWS/uOxNuYWIiIjYyqbCRd++fXM6DhERkQJnz+/n+fT73wHwrlqWoxUrgwEuJhhQ2s7B2ZlyCxEREbGVZr4SERHJAWazmZdmbLS+rjyqFwmGZYjF8LJQSpNyioiIiNjEroWLLVu2EBAQkGZbXFwc77zzDp06dSIgIIBHHnmE9evXp2mTkJDAW2+9RevWrQkICGDkyJFcunQpTZvIyEjGjx9PixYtaNasGRMnTiQqKipNmwsXLvD888/TpEkTAgMDmTlzJgkJCTlzsSIiUqi8uWQ72/edBaD0fQ054l3c8r0zvFbJnpEVbMotRERECh6bHhXJCfv37+fll19Ot33KlCls3ryZF154gWrVqrF161ZefPFFALp27QrA5MmT2bp1K+PGjcPDw4M5c+YwdOhQ1qxZg6OjIwAjRowgLCyMKVOmEBcXx8yZM7ly5QpLly4FLAnKwIEDcXNzY+bMmVy4cIFZs2YRFxfHa6+9lku9ICIiBdHGHSd5beFP4F8D2jXjSsNa1n1vVYYidvv0LdiUW4iIiBRMuZ46JSQksHLlSubNm4eHhweJiYnWfdeuXeObb77hjTfeoGfPngAEBgZy9uxZVqxYQdeuXTl79ixr165l9uzZ1mSjdu3adOnShS1bttC5c2dCQkLYtWsXX375JQ0bNgSgbNmy9O/fnyNHjlCvXj2+++47zp49y5YtW6wTg7m6ujJlyhSee+45SpYsmcs9IyIiBcHF8Jv0fG8fvDYMKls+X8y39rX00twWOUG5hYiISMGW5aMikZGRfPDBBwQFBbF27VqSkpLStTl37hxTpkyx+Q23bdvGsmXLGDt2bLqJuaKjo+nduzf33HNPmu1Vq1YlLCwMgJCQEADatm1r3e/r60vNmjXZvn07AMHBwZQoUcKaWAC0aNECLy8va5udO3dSt27dNLOZd+zYkaSkJIKDg22+HhERkdQGL93FzUGPWYsWAGWdYXwF2FC3cK8kAsotRERE5M5lOuIiPDycnj17cvHiReu25cuXs3jxYipWrGjddvnyZb744gubE4z69euzZcsWfHx8WLBgQZp9lSpVYurUqWm2JScns23bNqpVqwbA6dOnKVmyJB4eHmnaVaxYkdDQUGubypUrp9nv4OBAhQoVrG1CQ0Px9fVN06ZYsWJ4eXlZ29ypkydP4uCQ/dOGxMbGAnD06NFsP3d+on5QH6RQP1ioH/JeH+w9cpl1jsXAyfJoQXVieM7zGp2cb+IUA3+fgL9z4H2zqx/MZvPtG/0Hyi3uTE7lFZD3fnbspbD3Q2G//tTUFxaFvR8K+/Wnlh19kZ15RaafhnPnziU5OZlPPvmEvXv38sYbb3D58mX69evH+fPn7/oNy5Qpg4+Pj83t58+fz19//cXgwYMBy50TT0/PdO08PT2tE2TZ0iYqKuq2bURERGyVmGRm8keHoWV9AJyTk/ikyDkecLmJUyEfZZFCuYWIiIjcjUxHXAQHB1tnxQZ47LHHaNCgAf369WPo0KF8/vnneHt752hwy5YtY8mSJQwcOJD27dsDYBgGJlP6DDD1dsMwMrxD8e/tmZ3nbu9u1KhRA1dX17s6NispVa46depk+7nzE/WD+iCF+sFC/ZC3+mDpF3s5XbkauLoA8FRZB1rU9MuV986ufoiPj+fw4cPZEVKGlFvcmZzKKyBv/ezYU2Hvh8J+/ampLywKez8U9utPLTv6Ijvzikw/Ra9fv06lSmnXa6tVqxaLFi3izJkzjBo1KseGlBqGQVBQELNnz+aJJ55g7Nix1n1eXl5ER0enOyYmJsaa7GTVxsvLy+Y2IiIitkhMTCbovR3Qrpl12/Dydl1xPE9SbiEiIiJ3I9OsqmLFiuzbty/d9qZNm/Lqq6+yc+fOdM+MZgez2czYsWP58MMPGTZsGJMnT05z98LX15crV64QFxeX5riwsDCqVq1qbXPu3Ll05z1//nyaNimTcqW4fv06UVFR1jYiIiK2+OT7Q5wpWgLKWVaNaOUNjdI/MVDoKbcQERGRu5Fp4eKhhx7i/fffZ+nSpfz1119p9vXu3Zt+/frxxRdf8MYbb2RrQNOnT+d///sf48ePt66xnlqrVq1ITk5m69at1m2hoaGcOHGCVq1aWduEh4dz6NAha5tdu3YRFRVlbdOyZUsOHz6cZoKwzZs34+zsTLNm/9wxExERyUpyspk3l26HHh2s24aXzeKAQky5hYiIiNyNTOe4ePrppzl16hTvvPMO58+f5/XXX0+zf+LEiQCsWrUqw+c578aRI0f46KOPaN26NQEBAfz222/WfQ4ODjRo0IDKlSvTpUsXJk2aRFRUFD4+PsyZMwc/Pz86duwIWBKHhg0bMnz4cMaOHUtSUhIzZsygbdu2+Pv7A9CtWzcWL17M4MGDGTVqFJcvX+btt9+mV69elCpVKluuR0RECr4vNxzhZOly4FsegHruBo+X1GycGVFuISIiIncj08KFi4sL06dP57nnniMmJibDNhMnTqR9+/b88MMP2RLM1q1bMQyDX3/9lV9//TXNPg8PDw4cOABAUFAQQUFBzJo1C7PZTGBgIBMnTsTR0bL8nMlkYvHixUybNo1Jkybh4uJChw4dmDBhgvV87u7ufPDBB7z++uuMGTMGb29v+vTpw+jRo7PlWkREpOAzm81MW7YD+j9u3RZUxYSj6hYZUm4hIiIid8NkGIZh7yDyu5TZUv39/bWqSA5SP6gPUqgfLNQP9u+DNT/+wf+tPQ19HwTgHm+Dbf4msmmwgM2ye1WRnPo8E9vkxv8He//s5BWFvR8K+/Wnpr6wKOz9UNivP7XsXFUkOz7PNOW5iIjIXTAMg6nLd0L3+6zbZlTJ/aKFiIiISEGnwoWIiMhdWP/LCQ5VqQ5FLMtcPlTMINDHzkGJiIiIFEAqXIiIiNyFNz7dB10CATAZBkFVNNRCREREJCeocCEiInKHDvxxgZAylcHN8rxm/9JQ18POQYmIiIgUUCpciIiI3KG5q0KgZX0AHAyDqZU12kJEREQkp2S6HOq//fDDD2zatIno6GjMZnOafSaTiWXLlmV7cCIiInnNpStRfHosArpbJrRo622mkqujfYPKp5RbiIiIiC1sKlwsW7aMOXPm4OLiQokSJTD9a8r0f78WEREpqJZ+sZekgH+WButTRkWLu6HcQkRERGxlU+Hiiy++oFOnTsyaNUvruouISKEVF5/Iws/3wPhnAHDE4JHi+gP7bii3EBEREVvZNMfF5cuX6dOnjxILEREp1D769iDhRYtDMctjIh2KmijpbOeg8inlFiIiImIrmwoXVapU4fLlyzkdi4iISJ6VnGxm9gfB0DrAuq1nCTsGlM8ptxARERFb2VS4GDx4MIsXLyYsLCyn4xEREcmT1m79k+MtmkKbxgA4meCR4nYOKh9TbiEiIiK2smmOi02bNhEREUGnTp0oW7Ys7u7uafabTCbWrVuXIwGKiIjYm2EYPHfaBJ1bWbdNq4QeE/kPlFuIiIiIrWwqXNy4cYNatWrldCwiIiJ50qQ9V7nsX9vywjCYX9VgRHmbBi1KJpRbiIiIiK1sKlysWrUqp+MQERHJk07FwfTYInBrdMVTkWcZUb6KfYMqAJRbiIiIiK10u0hERCQThgGP/Z5IsrOlauF24ChLO1Swc1QiIiIihUumIy4aNmzIypUradSoEQ0aNMBkynydepPJxG+//ZYT8YmIiNjN/mj4LfHWUIvw64xzu46bq02DFSUDyi1ERETkbmSafXXt2pXixYtbv88quRARESmIpgVfBM+yALj8vIcXpt5r54jyN+UWIiIicjcyLVwEBQVZv58+fXquBCMiIpJXLPpkN986VgJPy+tn/Lwo6uOe9UGSJeUWIiIicjc0x4WIiMi//Lr/LMMX/wqVywFQ4kYkc4e2tHNUIiIiIoWTHtQVERFJxWw2M/LNH6Chn3Xbs3V8cHDQYw0iIiIi9qDChYiIyC2GAQM3nGN/zdrQoKZ1+yMlVLQQERERsRcVLkRERG758HwCK4tWgYeqWLeVd4HGnnYMSkRERKSQs+scF1u2bCEgICDNNsMwWLx4MW3btqVhw4YMGDCAU6dOpWmTkJDAW2+9RevWrQkICGDkyJFcunQpTZvIyEjGjx9PixYtaNasGRMnTiQqKipNmwsXLvD888/TpEkTAgMDmTlzJgkJCTlzsSIikudNORSVbtujxUGLX+Qfyi1EREQKnjsacfHXX38RHR2NYRjp9jVo0OCO3nj//v28/PLL6bYvWrSIZcuWMWbMGCpUqMDixYvp378/69evx9vbG4DJkyezdetWxo0bh4eHB3PmzGHo0KGsWbMGR0dHAEaMGEFYWBhTpkwhLi6OmTNncuXKFZYuXQpYEpSBAwfi5ubGzJkzuXDhArNmzSIuLo7XXnvtjq5FRETyvy0nr3O2qGWpTq5F8lhFV4p6ufFGZfvGVdAptxAREZHbsalwcerUKUaNGpXu7gRY7mKYTCaOHj1q0xsmJCSwcuVK5s2bh4eHB4mJidZ9UVFRLF++nOHDh/PUU08B0LRpU9q1a8fq1asZMGAAZ8+eZe3atcyePZuuXbsCULt2bbp06cKWLVvo3LkzISEh7Nq1iy+//JKGDRsCULZsWfr378+RI0eoV68e3333HWfPnmXLli2ULVsWAFdXV6ZMmcJzzz1HyZIlbboeEREpGJ7dch7qFwOg9c1wvmpUw84RFWzKLURERMRWNhUupk+fzqVLl3j22WepUKECDg53/4TJtm3bWLZsGWPHjiUiIoIPPvjAuu/gwYPExMTQoUMH67YiRYrQvHlztm/fzoABAwgJCQGgbdu21ja+vr7UrFmT7du307lzZ4KDgylRooQ1sQBo0aIFXl5ebN++nXr16rFz507q1q1rTSwAOnbsyKuvvkpwcDDdu3e/62sUEZH8Zf2Ok5yoUMnywmyw9P6K9g2oEFBuISIiIrayqXCxd+9eJkyYQM+ePf/zG9avX58tW7bg4+PDggUL0uwLDQ0FoFKlSmm2V6xYka1btwJw+vRpSpYsiYeHR7o2KcefPn2aypXTju11cHCgQoUK1jahoaH4+vqmaVOsWDG8vLysbe7UyZMn/1PilZnY2FgAm+88FVTqB/VBCvWDhfohe/ogMcnMoE/+hH49AKgRdQWHS1c4euk2B+Yh2fVvwWw2Z0c4NlFucXs5lVeAfn+kKOz9UNivPzX1hUVh74fCfv2pZUdfZGdeYVPhwtnZOc3dg/+iTJkyme6LiorCxcUFFxeXNNs9PT2tk19FR0fj6Zl+endPT08uXrx42zYp54mKirptGxERKfg+23iSiy2bWl8/UybejtEUHsotRERExFY2FS7uvfdefvrpJ+69994cDSblmdaMpGzPrE3q7YZhZHiH4t/bMzvP3d7dqFGjBq6urnd1bFZSqlx16tTJ9nPnJ+oH9UEK9YOF+uG/98GV69EsOHIYhljupFcwJTKqYUWc7brm1p3Lrn8L8fHxHD58ODtCui3lFreXU3kF6PdHisLeD4X9+lNTX1gU9n4o7NefWnb0RXbmFTYVLh5++GHGjh1LbGwsTZs2xd3dPV2blMms/gtvb28SEhJITEzE2dnZuj06Oto667eXlxfR0dHpjo2JiUnTJjw8PMM2Xl5etz1PShsRESnYJs3/iegubayv367hnO+KFvmVcgsRERGxlU2Fi6FDhwLwzTff8M0336TbbzKZsiW5qFKlCoZhEBYWRtWqVa3bU7/29fXlypUrxMXF4ebmlqZNkyZNrG3279+f5txms5nz589bJ8by9fUlLCwsTZvr168TFRWV5r1FRKRgOvTnRZaGJUMny2MGdZ2Tebyko52jKjyUW4iIiIitbCpcfPTRRzkdBwABAQG4urqyefNmhgwZAkBkZCS7d+9m+PDhALRq1Yrk5GS2bt1qTWhCQ0M5ceJEmjZLly7l0KFD1jXgd+3aRVRUFK1atQKgZcuWTJ06lYsXL1qfsd28eTPOzs40a9YsV65XRETswzAMBr6/F+PJf/4wfruGIw4ZP1EgOUC5hYiIiNjKpsJF8+bNczoOwDJ5Vd++fZk3bx4ODg74+vqyZMkSvLy8rLOOV65cmS5dujBp0iSioqLw8fFhzpw5+Pn50bFjR8CSODRs2JDhw4czduxYkpKSmDFjBm3btsXf3x+Abt26sXjxYgYPHsyoUaO4fPkyb7/9Nr169aJUqVK5cr0iImIfy7acZF/7tuBieXTgsaLJPFBUoy1yk3ILERERsZVNhQuAS5cusWDBAnbu3MnNmzcpVqwYLVu25Nlnn6VcuXLZFtDo0aNxcHBgxYoVxMTEEBAQwPTp063PmAIEBQURFBTErFmzMJvNBAYGMnHiRBwdLUmnyWRi8eLFTJs2jUmTJuHi4kKHDh2YMGGC9Rzu7u588MEHvP7664wZMwZvb2/69OnD6NGjs+1aREQk74m4Ecuoc07gZ5lzoGZSDB/5eZDJ/I2Sg5RbiIiIiC1MhmEYt2t08eJFHnvsMSIiImjUqBGlSpXi0qVLHDx4kKJFi7JmzZoslyIr6FJmS/X399eqIjlI/aA+SKF+sFA/3F0fPPb6Rr7ueD8ALtExnL3PnTIu+btqkd2riuTU51lqyi0ylxv/H/T7w6Kw90Nhv/7U1BcWhb0fCvv1p5adq4pkx+eZTSMu3nnnHQDWrl1LjRo1rNtPnjzJgAEDmD9/Pm+++eZ/CkRERCSn/W/rMb6OdrG+HlbOlO+LFvmVcgsREZG85dNwWHABJlSEGrdvnqtsWvRt+/btPP/882kSC7CsL/7ss8+ybdu2HAlOREQku9yIiuOZqd9DYCPrthdqpF+CU3KHcgsREZG8I9EMz5yCkCiYcd7e0aRnU+EiNjaWihUrZrivYsWKREREZGdMIiIi2W7qol+4WLwUlCoGQDsfg6putzlIcoxyCxERkbxjfzREmS3fl3fJuq092FS4qFKlCsHBwRnuCw4Opnz58tkalIiISHY6fPwScz8Ogfb/rGQxsIweEbEn5RYiIiJ5x7Yb/3x/j/dtp8HMdTYVLnr27MlHH33EsmXLCA8PByA8PJxly5axatUqHn744RwNUkRE5G5dj4zl6Tc3Yh7+JDSxTDDl4wg9its5sEJOuYWIiEjekbpwcei73fYLJBM2Tc7Zu3dvgoODmTNnDu+88w4mkwnDMDAMg3bt2jF06NCcjlNEROSO/Xb0Aj1Gf83pQY9D+VLW7TOqgIejHQMT5RYiIiJ5hNmAXyLMgANEx3Iy+Bi0aX7b43KTTYULR0dHFi5cyM6dO9m5cyeRkZEULVqUVq1aERgYmNMxioiI3LEDf1zg3n4riG7RyFq0KEIyn9Vx5IFi9o1NlFuIiIjkFYdj4KZx62GME2d5tL2ffQPKgE2FixSBgYFKJkREJM+KM4OLCS6F3+Sh5z8jOsEMXe+17l/n70hrHzsGKOkotxAREbGv/4XFApaV1tzOnGfga60JO/uXfYP6l0wLF1OmTGHQoEFUqlSJKVOmZHkSk8nE5MmTszs2ERERm+2PgnZHoISjQZFF3xJ28Qa0awbFLZWKzkVR0cLOlFuIiIjkLfFm+PjPG1DSUrh4rKoX3p6udo4qvUwLF59//jkPPfQQlSpV4vPPP8/yJEouRETE3j68DDeS4UayCarVgv1ncOjehlsrezGlkl3DE5RbiIiI5BWJZuhyFLZGAiXLWDbGJzD14bz3mAhkUbg4duxYht+LiIjkRQeiU724rwmmYt6Yi3gDcH9RaOVtl7AkFeUWIiIiecOPEbeKFqmUi7hOtXJl7BLP7dzRHBciIiJ5kdmAA1EGYLJscHLEaGxZ+tTVBLOq2C82ERERkbwm9fKn/B0OVyKY27qovcK5rSznuLCVhnOKiIg9nYqDaMOU4b63fcHfM3fjkYwptxAREckb0hQu5qyiXa3i9BrW317h3FaWc1zYSsmFiIjY04f7L4KpLACmqBgMLw8AuhaF4WXtGJikodxCRETE/mKSYW/KI7aXr8H1G7zUv5tdY7odm+a4EBERyavi4pN499dzcI+lQvF0/EUcqlUjxgwLqoIp44EYYgfKLUREROwvJAqSjFsvTpzFr2oJHmhTw64x3Y7muBARkXxtxbd/ElG2kfX1hA6+1PSwXzwiIiIiedm21JNyHj/DS/0DcXBwsFs8ttAcFyIiki+di4e3rhXlqwM34BnLaAsvzFR3z9sfvIWZcgsRERH7W38xHnAFoNSVcJ565EH7BmQDzXEhIiL5TngitDkMoaZy8OJT4Gz5OGvs44CDHg3Js5RbiIiI2FeCGfbHOVoqARE3ebl7HVxd8v6DGJrjQkRE8pUEMzz2J4TG39rg/M9HWYBWD8nTlFuIiIjY17enbpDs5AOA8+kwhvVvaueIbKPxtCIikq+MCf3XEl6pqHAhIiIikrkpv4RZv+9QzAFvT1c7RmO7TEdcDBkyhPHjx1O9enWGDBmS5UlMJhPLli3L9uBERERSi06GpZduvUhMghVrcXjyAcxelopFUy/7xSa3p9xCRETEfkJ+O8cf3sWtr6d3rGzHaO5MpoWLU6dOERcXZ/0+K6ZsXmsuOTmZFStW8OWXX3LlyhVq1KjB6NGjadWqFQCGYbBkyRK++OILrl+/TuPGjXn11VepXr269RwJCQnMmjWLdevWERMTw7333svEiRMpU6aMtU1kZCRBQUH89NNPmM1mOnfuzCuvvIKXlzJfEZG86OdISEhZvmvX77D7MKO7VGJ3+Rbc6wP1tJpInmav3EJ5hYiIFHaGYfD84p3w9OMAlI+PpmHp/DNUNdPCxdatWzP8PjcsX76cuXPnMnLkSBo0aMDXX3/NkCFD+PLLL6lbty6LFi1i2bJljBkzhgoVKrB48WL69+/P+vXr8fb2BmDy5Mls3bqVcePG4eHhwZw5cxg6dChr1qzB0dERgBEjRhAWFsaUKVOIi4tj5syZXLlyhaVLl+bq9YqIiG02RKR68ftJ7mtSjgENvXm7rr0ikjthr9xCeYWIiBR2X6w/zH5nH+vrAb7udozmzuXJ6UO/+eYbunXrxrBhwwBo0aIF+/btY/Xq1YwePZrly5czfPhwnnrqKQCaNm1Ku3btWL16NQMGDODs2bOsXbuW2bNn07VrVwBq165Nly5d2LJlC507dyYkJIRdu3bx5Zdf0rBhQwDKli1L//79OXLkCPXq1bPPxYuISKbWXkwEnMFsxvXUGSa8eV+2j/qTgkd5hYiIFGaXrkQx/I31MLindVuPUvlrukubChdRUVHMmzePffv2ERkZmW6/yWRi8+bN2RZUQkJCmmGVjo6OeHt7ExkZycGDB4mJiaFDhw7W/UWKFKF58+Zs376dAQMGEBISAkDbtm2tbXx9falZsybbt2+nc+fOBAcHU6JECWtyAZZExsvLi+3btyvBEBHJYw5diyfs1prjnD7PlAEtqFRWQ/Dzq9zMLZRXiIhIYWUYBs9O/Z6rCQbU8gWgootBgGf+uvFjU5ll8uTJrFq1CrB8UFetWjXNl6+vb7YG9eSTT/Ltt98SHBzMzZs3WblyJSdOnKBr166EhoYCUKlSpTTHVKxY0brv9OnTlCxZEg8PjyzbVK6cdjISBwcHKlSoYG0jIiJ5x/Bvjlu/rxB+mTEDAu0YjfxXuZlbKK8QEZHC6pPvDvHN5mMQUBscLX/+P1TcRH4bsGrTiIsdO3bwzDPP8OKLL+Z0PAD06dOHkJAQ+vfvb932wgsv0KFDB5YuXYqLiwsuLi5pjvH09CQqKgqA6OhoPD3TTzTi6enJxYsXb9sm5Tx36uTJkzg4ZP+Qm9jYWACOHj2a7efOT9QP6oMU6geLwtQPYZei2B7nbX09upEbJ04cL1R9kJXs6gez2Zwd4dgkN3ML5RXp6WfHorD3Q2G//tTUFxaFvR8K2vWfPBfJ0Mmbwd0VHm1v3d446gxHj8ZkeWx29EV25hU2z3HRpEmTbHvTrBiGwaBBgzh16hSTJ0+mevXq7Ny5k0WLFuHj44NhGJk+z5yyPbM2qbcbhpFhMpDZdhERsZ9Pt4RCu4cAcE2Ip3NZ/Z4uCHIjt1BeISIihVF0bCIvzPyV2Lgk6Hs/FLNMzNnSKZpWTlkXLfIimwoXXbp0YcOGDbRp0yan42Hfvn3s27ePuXPn8sADDwCWZ0STk5N5++23efHFF0lISCAxMRFnZ2frcdHR0daZv728vIiOjk537piYmDRtwsPDM2xzt8uW1ahRA1dX17s6NispVa46depk+7nzE/WD+iCF+sGisPRDQkISX185Dm6W369dijvgX9dyzYWlD24nu/ohPj6ew4cPZ0dIt5VbuYXyiozpZ8eisPdDYb/+1NQXFoW9HwrS9T81bg1/XYqFds0sX4CbA6yq70kN99tfX3b0RXbmFTYVLsaNG8fjjz/OE088QUBAAO7uaZdOMZlMPP/889kSUMqQy0aNGqXZ3qRJE9577z1MJhOGYRAWFkbVqlWt+1O/9vX15cqVK8TFxeHm5pamTcrdHV9fX/bv35/mPcxmM+fPn6d79+7Zci0iIvLffbP5GDcb/rPe6bBKzlm0lvwit3IL5RUiIlLY/LDtBKtCY2HmC1Dkn+L51EpQI3+tgmpl09jF1atXc+LECfbv38/y5ctZuHBhuq/skjIZ178//A8ePIiTkxOdO3fG1dU1zUzjkZGR7N69m1atWgHQqlUrkpOT06wRHxoayokTJ9K0CQ8P59ChQ9Y2u3btIioqytpGRETs5/uf/uTNJduY8vFe8K8OQAkjiU5F7RuXZI/cyi2UV4iISGFyMzqeASv2w3OPpylaPFocXixnx8D+I5tGXKxYsYLAwEDGjBlD6dKlczQgf39/2rZty9SpU4mIiKB69ers3r2b999/n6eeeoqyZcvSt29f5s2bh4ODA76+vixZsgQvLy969rSsS1u5cmW6dOnCpEmTiIqKwsfHhzlz5uDn50fHjh0BaNmyJQ0bNmT48OGMHTuWpKQkZsyYQdu2bfH398/RaxQRkax9teEIvV78yvLi/kC4NUfAoAqOOOazWbAlY7mVWyivEBGRwmT4shAuPdEdnC1/6rfzMZhW2URrHzsH9h/ZVLi4fv06AwcOpG7durdvnA3mzZvH3LlzWbJkCZGRkVSpUoWJEyfSu3dvAEaPHo2DgwMrVqwgJiaGgIAApk+fbn3OFCAoKIigoCBmzZqF2WwmMDCQiRMn4ujoCFiGoC5evJhp06YxadIkXFxc6NChAxMmTMiVaxQRkYzdjI7nhaANlhdeHnBPgHVf/9KqWhQUuZlbKK8QEZHC4MLlm6wqXcOSPwHNXBL5oa4zrgVgjmibChd16tTh3LlzOR2LlZubG+PHj2f8+PEZ7ndycmLMmDGMGTMm03N4eHgwbdo0pk2blmmbEiVKMHfu3P8aroiIZKPX3/2Fv6/GwNPdMbVuhHHrD8PmXgZ1PFS4KChyM7dQXiEiIoVB0NeHMBq2BsAnLoaNzT0KRNECbCxcjBkzhtGjR+Pq6kqTJk3w9PRMtyxYiRIlciRAEREpPI6cuMzcj0KgSV1o0wTj1nYT8HJ5FS0KEuUWIiIi2Sc2LpEP/rwJDS2v+5U2Ucymv/bzB5suZfjw4URHRzNx4sRM26QslyIiInI3DMNg+BvrSUoyQ60q1u39S8G4ClDbw47BSbZTbiEiIpJ9Pv7fIaKqVrK+7lUpny4fkgmbChdPPvlkursgIiIi2enz9Yf5eXcoAM51fEnEMtJiTlUK1B0DsVBuISIikj3MZjPvrNoFIwcA4I6ZVt4F5BmRW2xKBUeMGJHTcYiISCF2IyqOl2ZstLxwdyOpTEkA6nmoaFFQKbcQERHJHt//fJyjyc7gaRll0amYCeeCVbeggF2OiIjkR1MX/cKF8CgAGj/UDOPWnfjW3lkdJSIiIlK4GYbBm0u3Q73q1m2dixa8EY0qXIiIiF39fvwSc1eFQO2qOJcuRoseraz7VLgQERERydzWkNPsPnQ+TeHi/qL2iyenaACuiIjYjWEYPP/6Osz33wP/1wFTchJbk//5aLrHx47BiYiIiORxby7dBrWrQg3LxJxVXaG6m52DygEacSEiInbzyXeH2P77BegSCECCoxN/xlr2lXMGX1c7BiciIiKSh+3Yd4afQm/Cc73AwfKn/dOloSDOfW1T4WLBggUcP348p2MREZFCJCo6nrGzNkGrBtbJpFJr7VMwP3jFQrmFiIjI3TMMg1cW/gIj+1jzqM5FYWJF+8aVU2wqXLz//vucPXs2p2MREZFCJOi9HZYJOTu0sG5zSlWo0PwWBZtyCxERkbu3NeQ0O1yKQVnLSmx+bgZf1EqbSxUkNhUuKleuzJUrV3I6FhERKSROh11n9gc7oW41qFAagOZesLSa5YPJywEeLW7fGCVnKbcQERG5O4ZhMHHeVuj4z82fFTVMFC3AM1jadGn9+vUjKCiIw4cPU6tWLUqWLJmuTdeuXbM9OBERKZhemrGR+IRkuD/Qum1UOXiilOUREW9HKO9ixwAlxym3EBERuTvfbjnGrgRn682fpp4GrbwL6FCLW2wqXLz22msArF69OsP9JpNJyYWIiNjkqw1H+GbzMfDzBf8aAFRwgcdKWPb7pZ/uQgog5RYiIiJ3LiY2gReCNkCPB6zbRpU3Ffh5wWwqXHz00Uc5HYeIiBQC4deieX7aOsuL/+to3T6lErhonatCRbmFiIjInZv+3g7OOLpDQz8Ayjgb9CxRwKsW2Fi4aN68eU7HISIiBdgn4XAw2uD4uz8Sfi0GAmpDdcu0137u0L+0nQOUXKfcQkRE5M6cPHOV6d8dhdFPg4OlWPFsWROuheDmj83Td8TFxfHpp5+ybds2Ll26xPz589m2bRsBAQE0btw4J2MUEZF87GQsPHUCzJigdiPYdAyHx+/HfGv/m5UL7gzYkjXlFiIiIrYxm830DdpM4si+UMQLgEaeMLq8nQPLJTbVZiIiIujZsydvv/02Fy9eJDQ0lISEBLZv386AAQM4ePBgTscpIiL51P5orEUKaleFV4dgLlUMsKwk0kOrhxRKyi1ERERst/DTPexqGAAligBQ29XMj3UtE5oXBjYVLubMmUN4eDhr1qzh+++/xzAMABYuXEj16tVZtGhRjgYpIiL519Go5LQbyllWj/BwgI9qUuAnk5KMKbcQERGxzckzV3l581loWAuAIkYSW+o7UMrZzoHlIpsKF1u2bGHkyJHUqVMHU6oM08vLi0GDBvH777/nWIAiIpJ/GYbBql3nM9y3sKpWECnMlFuIiIjcXuTNOLqP/pqEx+63bltYy6nQLRtvU+Hi5s2bVKxYMcN9Pj4+REdHZ2tQIiJSMEx/bwenEv75o7QIltEXT5XShJyFnXILERGRrCUlJfN/Y7/hWOd2UNwHgPu8knmypJ0DswObChe+vr789NNPGe4LDg7G19c3O2MSEZECYEvwX0x4ZwuUKQFAEXMifzVzZIc/fFBDj4gUdsotREREsvbcOz+z5Z42UL8mAK4YLKvpWChzKJtWFXniiSeYOnUqjo6OdOzYEZPJxPnz59mzZw8ff/wx48aNy+k4RUQkH4mJTWDo5O/A0x28PABoUNSZ4s7QuhA9jymZU24hIiKSuaU//cV7NQKgjGUWc3fMfFvXgVqF9DFbm0Zc9O7dm/79+/Ppp58yYMAADMNg1KhRzJgxg549e/Lkk09me2DBwcH07NmTBg0a0K5dO+bPn09ysmWIsWEYLF68mLZt29KwYUMGDBjAqVOn0hyfkJDAW2+9RevWrQkICGDkyJFcunQpTZvIyEjGjx9PixYtaNasGRMnTiQqKirbr0VEpLB5/d1f+OvcdetoC4BabnYMSPKc3M4tlFeIiEh+seFsFM8mlLEWLbyTEvi1gQOdito3LnuyacQFwLhx43jiiScIDg7m2rVr+Pj40LJlS6pVq5btQe3bt48hQ4bQrVs3Ro8ezZEjR5g3bx4ODg4MHz6cRYsWsWzZMsaMGUOFChVYvHgx/fv3Z/369Xh7ewMwefJktm7dyrhx4/Dw8GDOnDkMHTqUNWvW4OhoWTNmxIgRhIWFMWXKFOLi4pg5cyZXrlxh6dKl2X5NIiKFxW9HLzDrg50AOJQvaV0KtaYKF/IvuZVbKK8QEZH8wmw2+L8jZowiljktPCMjOdjWh6qFdKRFCpsLFwCVKlXCycmJyMhISpQoQalSpXIkqNmzZ9O6dWumT58OQKtWrYiIiGDXrl3079+f5cuXM3z4cJ566ikAmjZtSrt27Vi9ejUDBgzg7NmzrF27ltmzZ9O1a1cAateuTZcuXdiyZQudO3cmJCSEXbt28eWXX9KwYUMAypYtS//+/Tly5Aj16tXLkWsTESnIEhOTGTDxW5KTLUtbtuzckJ239hXWoY2StdzILZRXiIhIfrFwxzliilQGwPFiOHvvcaeqeyGc1OJfbHpUBGD9+vV06tSJ9u3b8+ijj9KmTRseeeQRQkJCsjWga9eusX//fnr16pVm+5gxY1i1ahUHDx4kJiaGDh06WPcVKVKE5s2bs337dgBrTG3btrW28fX1pWbNmtY2wcHBlChRwppcALRo0QIvLy9rGxERuTPT39vBb0cvAuBXtQRl61Wx7lPhQv4tN3IL5RUiIpJfJCebeWPXZevrJ7wSqF3ay44R5R02FS5+/PFHRo8ejYuLC88//zyTJ0/m2WefJS4ujsGDB7N///5sC+jPP//EMAw8PDwYNmwY9evXp1WrVixYsACz2UxoaChguUOTWsWKFa37Tp8+TcmSJfHw8MiyTeXKldPsd3BwoEKFCtY2IiJiu0N/XmTakl8sL6pXZNK0xziVYPmYMQHV9aiIpJJbuYXyChERyS8++vYg4b7/fJZMu7ecHaPJW2x6VGTJkiW0bt2a9957DweHf2odw4cPZ+DAgcydO5ePPvooWwK6fv06AGPHjqVbt27079+fPXv2sHjxYlxdXTEMAxcXF1xcXNIc5+npaZ0AKzo6Gk9Pz3Tn9vT05OLFi7dtc7cTaZ08eTJN/2SX2NhYAI4ePZrt585P1A/qgxTqB4u81A+JSWb6jN9MYqIZWjeCgY/QL97AuLW/vEMCp/88ldUp7kpe6gN7yq5+MJvNt2+UTXIrt1BekTH97FgU9n4o7NefmvrCorD3gz2vPy4+iZdX7oFxAQD4xt8gJvQ89vo/kR19kZ15hU2fhqdOneLJJ59M9+Hp4OBA3759+f3337MtoMTERADuuecexo0bR8uWLRkxYgS9e/dm8eLFmM1mTJksXJuy3TCMDNuk3p5Vm5xKEkRECqrla4/xx1/XwcsDh973A2Dwz+/YKg4J9gpN8qjcyi2UV4iISH6wat0Jrlaran39UJE4O0aT99g04qJUqVLplvxKERUVRdGiRbMtoJS7Fffee2+a7YGBgXzyySf4+PiQkJBAYmIizs7O1v3R0dHWmb+9vLyIjo5Od+6YmJg0bcLDwzNs4+V1d88R1ahRA1dX17s6NispVa46depk+7nzE/WD+iCF+sEir/TD4eOXWPzVEcuL/+uA2SP9ZBaNSnpRp1r2x5lX+sDesqsf4uPjOXz4cHaEdFu5lVsor8iYfnYsCns/FPbrT019YVHY+8Fe13/lejTL166FkX2t256pXZo6HqVzNY7UsqMvsjOvsOkWwLPPPsu8efM4cOBAmu2nT59mwYIFPP/889kSDGB9PjTlDkmKpKQkAJycnDAMg7CwsDT7w8LCqFrVUqHy9fXlypUrxMXFZdnm3LlzafabzWbOnz9vbSMiIllLSrKsIpKYaIaqFaBNEwA8HeD/iv/TrqXmlZJ/ya3cQnmFiIjkdW8s3saNRnWhumW+pVpuUEeTmqdhU+Fi06ZNGIbBE088Qffu3RkyZAj/93//R/fu3bl48SIrVqyga9eudO3alQcffPA/BVSjRg3KlCnDhg0b0mz/5ZdfKF26NA8++CCurq5s3rzZui8yMpLdu3fTqlUrwLLMWXJyMlu3brW2CQ0N5cSJE2nahIeHc+jQIWubXbt2ERUVZW0jIiJZm/XBTvYe/hsA7273WLe/Vgm+8IN3q8HbVaBPzqyeLflYbuUWyitERCQv+/P0FRbuvQT9ulm3vVQeMnmKsdCy6VGR6OhoatWqZX0dFxeHh4cHAQEB2R6Qg4MDo0ePZty4cUyePJkuXbqwc+dOvvnmG6ZMmYKXlxd9+/Zl3rx5ODg44Ovry5IlS/Dy8qJnz56A5e5Kly5dmDRpElFRUfj4+DBnzhz8/Pzo2LEjAC1btqRhw4YMHz6csWPHkpSUxIwZM2jbti3+/v7Zfl0iIgXNHycvM3nBz4Dlw7V4o+rcBByB4WXB0QTPlrVjgJKn5VZuobxCRETyKsMwGDxjM8nP9AQnRwCGlLF8SVo2FS5WrVqV03Gk8cgjj+Dk5MTSpUtZs2YN5cqVY+rUqTz++OMAjB49GgcHB1asWEFMTAwBAQFMnz7d+pwpQFBQEEFBQcyaNQuz2UxgYCATJ07E0dHyD8JkMrF48WKmTZvGpEmTcHFxoUOHDkyYMCFXr1VEJD+KT0jiqfHfkJCYDMCwpwNZgmVVhroe4OFoz+gkP8jN3EJ5hYiI5EWfrfudHWUqg7dlPqZ7PM0srOqg0RYZsKlwYQ/dunWjW7duGe5zcnJizJgxjBkzJtPjPTw8mDZtGtOmTcu0TYkSJZg7d+5/DVVEpNB5acZG9h25AEC1SsV4ZEA7Fp+07Guq+SwkD1JeISIieUnEjVhGLfkVXh4CgJNh5mM/B1y0EFWG1C0iInJHvlh/mEWf7gHA2dmBz2c/xh9J/6zG0MTTXpGJiIiI5A8j3/yBK/c0B2fLWILnypmo4mbnoPIwFS5ERMRmh/68yKBJ31pfB41/gGb1K7Av1UqRTTTiQkRERCRTX//4B6tCwqC1ZV4nD5PBxIp6PiQrefZRERERyVsuX43ioec+IzomEXw8Kffyk4wpX55zp2FflKWNI9DQw65hioiIiORZf1++wTOTv4OubcHRMo5gdAUTpV3sG1dep8KFiIjcVkJCEv836kvO/B0Jfr44Pd+LC56WCsW8C5Byj6CuB7hrYk4RERGRdG5ExfHgsE+5GmeG1o0AcDUZjCqn0Ra3Y3PhIikpiRs3blC8eHEMw+Dzzz/n3LlzPPDAA9SvXz8nYxQRETsyDIPnXl/Hjn1noXgReOEJklzS3hYwbv1X81vInVBuISIihUV8QhKPjviC345ehPbNwc0VgD4lTZR0vs3BYtscF3/99RedOnXiww8/BOCdd95h6tSprFixgj59+rBnz56cjFFEROxo/qpdLP/6AACmPl3gVtGijQ9U/NewRq0oIrZSbiEiIoXFtYgYHhj6MVtDToPJhEOnFtZ9I8rZMbB8xKbCxdy5czGZTLRr147k5GS++OIL7r//fnbv3k3Lli1ZuHBhTscpIiJ28Ov+s4yesdHyom41jMZ1ACjuBGv8YEqltO01MafYSrmFiIgUBifPXKVl7/f56boBrz0DS17FXLoEAK29obFyJ5vYVLjYvXs3L774IgEBARw8eJDIyEh69eqFj48Pffr04fDhwzkdp4iI5LLYuEQGTvwWs9kAF2eKPdvDui+oMpRwhqdLQ213yzZPB2igiTnFRsotRESkoDt3IZJ2/VdyolgpGN0PqpQDp38mAxup0RY2s2mOi9jYWEqVKgXAzp07cXZ2pmnTpgC4uLhgGEZWh4uISD40ZeHPHA+9CiYTRV/sw3UPyy2Bpp4wqIyljZPJMvJi+nnoUQI8NDGn2Ei5hYiIFGRXrkfTefAqwmrWgH7drCuIVHEFP3do5wM9S9g5yHzEpsJF+fLl+f3332nZsiWbN28mICAAV1fLZCJbt26lYsWKORqkiIjkrl0Hw5j1wU4ATD3aE1GrGmAZVbG8Bjimmvy6jgesrGmPKCU/U24hIiIFVVJSMg+/sJpj97aCNk2s23uWgI9rgotNzz1IajZ1Wffu3Zk3bx4PPPAAx44d47HHHgNg+PDhfP755zz++OM5GqSIiOSeyJtxPPHy15ZHRKpWwOh6L2BZ8vSTWtBAK4dINlBuISIiBdWLH+1n5wOd0xQthpWBz2qpaHG3bBpx8dxzz+Hs7Mzu3bvp06cPDz30EABRUVGMHj2aJ598MkeDFBGR3GEYBs9M/o6/zl0HoNSDLQm/tW9qJXi4uP1ik4JFuYWIiBREE/ZfZ2H1AHC2/KntjMG71U0MLmPnwPI5mwoXAEOGDGHIkCFptqUsYSYiIgXDsi/38cWPx8BkwtPDGYcmdcEMjsDzZe0dnRQ0yi1ERKQgeeNkPEFxxcDZ8rpYbDQ/tvDUcvHZwObCBcDGjRvZtm0bFy9eZNKkSfz2228EBARQpUqVnIpPRERyyfa9Z3h+QygsHA9/hzOyeBxBZstsm+2KQHFn+8YnBZNyCxERKQhmnUlk0mVX6+viB49wor8fxd3tGFQBYlPhIj4+nmHDhhEcHIy7uztxcXFER0fz9ddfExQUxKeffkr16tVzOlYREckhZ/+O4OGgLSQP7wcuzuBbnqVOQJJl//9p1mvJZsotRESkIDAMmHY2mcnn/7nD47E1hF39alHc/Y7GCUgWbJoaZN68eRw4cICFCxeya9cu6xJlQUFBFClShIULF+ZokCIiknMibsTSZeRXXH/iIXD950P32q2ihQnNbSHZT7mFiIjkd2YDXjhtMPn8P+vBu2wJYUePKtSoouQpO9lUuFi/fj3Dhw+nY8eOODr+8z+lYsWKDBs2jD179uRYgCIiknP+upmI/6d/cXTIk1CuJAAeJiNNm0BvKOdij+ikIFNuISIi+VmCGfoeN5h/8Z814h2/+5mNncsSULec/QIroGwqXFy9ehU/P78M95UpU4bIyMhsDUpERHLeyehk6u1K5HyDeuDtAYC7ySCkgQl/j3/a9dBjIpIDlFuIiEh+FZsMD/yexGdXbxUtzAamj9exukMZ2rbwtWtsBZVNhYvy5cuzd+/eDPcdPHiQ8uXLZ2tQIiKSs87Hmgn4NYY4j1sViqRk2jnEENzARH1PWFUTKrhAfQ8YUNq+sUrBpNxCRETyI7MBHYNvsjX61vwVScmw9Cvea1+ORzrWsW9wBZhNs4U8+uijLFq0iKJFi9KxY0cAEhIS2LRpEytWrGDgwIE5GqSIiGSfq7FJ1P8piqiiRS0bLl9jRZHrDGj5z0SIjTzhXBMwmTI+h8h/pdxCRETym9Dz13lo82V+r3lrxGB8At4frOGzQY15sG0t+wZXwNlUuBgyZAh//PEHM2bMYObMmQA88cQTANx3330MHTo05yIUEZFs8/flm9TfcIXrNapaNly/wbueVxnQrma6tipaSE5SbiEiIvnFnt/P8/qyHXzvUx4evNey0WxQ/5cd/PB2VyqU8bFvgIWATYULR0dH5s+fz65du9i5cyfXrl3Dx8eHwMBAWrdundMxiojIf2AYMPcC7LyawPd7womrXc2yIy6emY6XeLZT+qKFSE5TbiEiInld6PnrjJ21ia/+jISnukHlfybdfDQyjNWvtcXBwabZF+Q/uqOFZVu0aEGLFi2sr2NjY7M9oNQSEhJ4+OGHadiwIdOnTwfAMAyWLFnCF198wfXr12ncuDGvvvpqmrXeExISmDVrFuvWrSMmJoZ7772XiRMnUqZMGWubyMhIgoKC+OmnnzCbzXTu3JlXXnkFLy+vHL0mEZHctuwSjA4FcIGUogUww+cGLzdV0ULsS7mFiIjkRV+sP8yghb8S3eUe6FnPut1kGIwuEc/brSppdGousrk89Nlnn7FhwwYADh8+zD333EPjxo0ZPnw4cXFxORLcwoUL+euvv9JsW7RoEYsXL2bgwIHMmTOHmzdv0r9/f27evGltM3nyZL799lteeuklgoKCOHbsGEOHDiU5OdnaZsSIEezevZspU6YwYcIEtm7dyksvvZQj1yEiYi9XE2HCWSPd9rHF4hjbtJQdIhL5h3ILERHJa2Ljk+j7xkZ6H4gl+pUh0PSfokUtN4PgBiZm1XZT0SKX2VS4+PDDD3n99dc5fvw4AG+++SZms5m+ffsSHBzMwoULsz2wP/74g1WrVlGsWDHrtqioKJYvX87w4cN56qmn6NChA8uXLyc6OprVq1cDcPbsWdauXcvkyZPp0aMHXbp0YdmyZfz5559s2bIFgJCQEHbt2sU777zDAw88wKOPPsqcOXP4+eefOXLkSLZfi4iIvYwPNXMt6dYn64FjuL79AV96XWZGHTf7BiaFnnILERHJa06ciaDryjN80qINtGsGjpY/l4s7GrzjC4camWjhbd8YCyubChdff/01vXv3ZuTIkYSHh3PgwAGee+45Jk6cyMiRI/nhhx+yNaikpCQmTJjAoEGD0gzBPHjwIDExMXTo0MG6rUiRIjRv3pzt27cDlsQBoG3bttY2vr6+1KxZ09omODiYEiVK0LBhQ2ubFi1a4OXlZW0jIpKfJRkwKzSR9y/fKlrEJ8BnP/DxsOb0bKD1TcX+lFuIiEheYBjw+41kun11kkfCynCpZzfwdAfA2ZzMhAoGfzUx8UJ5cNV0FnZj0xwXZ86cYcKECQDs3LkTk8nEfffdB0CtWrW4fPlytgb13nvvkZiYyNChQ9m0aZN1e2hoKACVKlVK075ixYps3boVgNOnT1OyZEk8PDzStUk5/vTp01SuXDnNfgcHBypUqGBtczdOnjyZI5OzpDzve/To0Ww/d36iflAfpFA/WGTWD6HJzoy8UYGTuMOtuoXDDzuYPaAe9So7FKh+078Fi+zqB7PZnB3h2ES5xe3lVF4B+tlJUdj7obBff2rqC4vC0g+GAYeS3VgTX5RN0e5EOLtBhRpQ4Z82LRKvMaPkVUrHJPH3CfjbfuHaRXb8W8jOvMKmwoWnpyfR0dGAJbkoW7as9QP+woULaYZc/lenTp1iyZIlfPjhh7i4uKTZFxUVhYuLS7rtnp6eREVFARAdHY2np2eG13Dx4sXbtkk5j4hIfnTF7MiAyEpcMrlatzntOsTipo60rl8uiyNFcpdyCxERyWkJBiyMLcXahKJUdEigjlMcN8yOHElyJdS49disc9pjXONiGe99hV5FozSPRR5iU+GiXr16rFixgri4ODZu3EiPHj0AOHLkCEuWLKFJkybZEozZbGbixIk89thjBAQEpNtvGAamTP71pGzPrE3q7YZhZHgHI7PttqpRowaurq63b3iHUqpcderUyfZz5yfqB/VBCvWDxb/7IToZHgmJ+6docekqRb/ZxNbx9xFQt4G9wsxR+rdgkV39EB8fz+HDh7MjpNtSbnF7OZVXgH52UhT2fijs15+a+sKiIPXD6Tjofxx2x1teX0l24rdkj/QNk5Lh5FnKhV/m+XouPFzNDf+6+f/6/6vs+LeQnXmFTZ+k48aN4+zZs4wZM4YiRYrwzDPPADBkyBDi4uIYNWpUtgSzatUq/v77b0aOHElSUhJJSUmA5UM/KSkJb29vEhISSExMTHNcdHQ03t6WWVK8vLysd3BSi4mJsamNliwTkfwmwQwrL5mpuC2W46Zbdw8iblLp02/ZM60TAXU10kLyHuUWIiKSU76+CgEHYXdWA95On4ePvqPh4pV8UzmOsJeb0aO6G44aZZEn2TTiombNmmzcuJFTp05Rq1Yt3NwsifFbb71F48aN8fHxyZZgNm/ezKVLl2jevHma7ceOHWPt2rW8/vrrGIZBWFgYVatWte5P/drX15crV64QFxdnjTOlTcrdG19fX/bv35/mPcxmM+fPn6d79+7Zci0iIjntxwRvPosvxqFdBrGGA7haJpIiLoHAbdv57r3eFC+awZ0FkTxAuYWIiGSnc/GwIQI2XIc111LtuBoBS1dDeARUKAU3YyhrjufBVlUZ+lwTmtWvkOnIO8k7bB676OnpSYMGDdJ8YLdt2xYfH58M7zDcjalTp7J69eo0X76+vrRr147Vq1fz4IMP4urqyubNm63HREZGsnv3blq1agVAq1atSE5Otk6oBZaJt06cOJGmTXh4OIcOHbK22bVrF1FRUdY2IiJ5ldmAcaHwQnRFdiV5Emuk+rA9FsqQvw6y/a0uKlpInqfcQkRE/qtz8TD0FFTdZzD01L+KFvuPwpQlcCqM1jWKMb9HbU4uf5y/N4/i/TcepnmDiipa5BM2jbhITk7m888/Jzg4mISEBAzDACx3EmJjYzl69CgHDhz4z8FUq1Yt3TY3NzeKFi1K/fr1Aejbty/z5s3DwcEBX19flixZgpeXFz179gSgcuXKdOnShUmTJhEVFYWPjw9z5szBz8+Pjh07AtCyZUsaNmzI8OHDGTt2LElJScyYMYO2bdvi7+//n69DRCSnJBvw+J/wdeoP5YibcPwMHvsO89nAAB5q18xu8YnYSrmFiIjcjYsJYMayMsiUE/F8GOlMkskB61JqAHHx8PUWnLbvpW+3BowZEEi9mloOPj+zqXCxcOFCFi9ejJeXF8nJyTg7O+Po6Mj169dxcHDgiSeeyOk4rUaPHo2DgwMrVqwgJiaGgIAApk+fbn3GFCAoKIigoCBmzZqF2WwmMDCQiRMn4ujoCFgm21q8eDHTpk1j0qRJuLi40KFDB+uybCIiedWcv1MVLcwGfPUj/BhM68aVWBn0KNUrF7drfCK2Um4hIiK2MgxYeyaKV8/AH86p5w1y/adeEZcAP+2BQ8epGHuDYT0CGDx1NGVKap6hgsCmwsW6devo0qULc+bMYf78+Vy+fJm33nqLAwcOMHToUGrUqJFjAX777bdpXjs5OTFmzBjGjBmT6TEeHh5MmzaNadOmZdqmRIkSzJ07N7vCFBHJcYeiDF45bUDKCgWLv8Tl9z95a2xnXniqJY6Od78qkkhuU24hIiL/djIWvr0G668bHI82Y45LIDY2gQgXNww3r3RLlwKQmAQ/7cF1czDt65Zm6IiWdGtbCycnx1yPX3KOTYWLCxcu8Morr+Dg4EDdunXZtGkTAAEBAQwcOJDVq1fTu3fvHA1URKSwMgzYFJ5Ir30xJBcpYtm4OQT/yIu8Nasz3Tu3tG+AIndBuYWIiBgGnI6HLRfjWBKWzH4Hz1t7TIAjOLtbvlK7EgHnL2PydKNU1E16cZ0eD1Sg1SsjcHPNqLIhBYFNhQsnJyfrOuKVK1fmzJkzJCUl4eTkRKNGjfjwww9zMkYRkUIp0QyfXoE3QpM4meQMKUWLv8MZ4X6TwUEdcXbSKAvJn5RbiIgULkkGbLscz7q/brLrehJ/mVwI9/AmydkZcEu/bERcAjg5WkaaRtzAJyaGlgkRPFvRkabNy1C+tDcODsqDCgubChc1atRg7969BAYGUrlyZcxmM8ePH6du3bpcv36d5OTknI5TRKTQMBvwSTi8ds4gNN5Eml/VN6II8opg/MudOHr0qN1iFPmvlFuIiBRMiWa4mgTXb8YSfPwKP5+LIiTWib/KlSfZyxNwhaKZHHw1Erbvx+PYSZoXd6ZNkyrc06QKge0r4ulRBCiXexcieYpNhYtHH32UN954g+TkZF588UVatmzJq6++yuOPP86KFSuoXbt2TscpIlLgnYiF9dfhg8twMAbSzI7913lK/f4H3w1sQAu/mvYKUSTbKLcQEcn/zGYzf128yZZzUWy/ksRusxunfYrfGkXhDlSCilmcIOImpvOXKBsbTROXRHqUdaLlM/74Vb1PoykkDZsKF0888QRXrlzhzJkzALzyyis8/fTTTJ48mSJFijBz5swcDVJEpCAzDBh5GhZezGDnsdPw3TYereTGijceoqiPewaNRPIf5RYiIvnLnrAbfHQskl8jDc45uBLh4UWSmys4FwGKQLHbnCA5GZ/QMGonRtGimBP3lXWlQV1vfDtVxdlZE2lK1mwqXACMHDnS+n3NmjXZtGkTf/31F9WqVcPT0zOLI0VEJCuz/s6gaHHuEqzeRMm//+bdSQ/y2P11MZlMGR4vkl8ptxARsa9kwzK1ROoUI9YMn5+6yY9no/ktMplQsxMRXt4YXj7g4QMetzlpdCymM3/j7epISQ9n/DxMtCrrxsBaPlS4t0pOXo4UYDYXLvbs2cP27dsZPXo0AKdOnWLevHkMHz6cgICAHAtQRKSguZAAQWGWx0HKOMPqqwbWx0LW74A9R+DsBXp39Wf+0ucpVVx/wEnBpNxCRCR3mQ04EQcbwxP55JKZvQkuuJmTKHXzBomxCVx3KEFsieLg5ASu3lA6i5NFx+IcE4M7BqXNCdR1SKB1UQcerO5Bzfuq4OJi85+aIrdl07+m7du38+yzz1KrVi1rcuHg4EBYWBhPPfUUK1eupHHjxjkaqIhIfmc2YOZ5eCMMos2p99wqWqzbDmu2ULakF4sXPM4jHevYI0yRXKHcQkQk59yMS2JTWDQ7L8dz9GYypxMcuOjgQqSnJ2YXF+DWsqEmiHF05kzREplPmAmYomLwvnGDOuZYOpZ0pEtlT5pVKoKra4ncuBwR2woXixYt4t5772XBggXWbf7+/qxfv54RI0Ywb948Vq5cmWNBiojkd4YBY0LhnQuZNDhwDL7ZylMPN+Sd8fdTvOjtxmGK5G/KLURE7s7VRPjssplN4Uk4xsbiFnmTK5Fx/B1n5pLJiUgPTxJLlbg19wTgncXJrt0AV2fw/GcOLdO1SMpeu0J9hwRalXblgRpFaeZbFAcH5SZiPzYVLo4fP868efNwckrb3NHRkccff5wxY8bkSHAiIgXF9POpihaGAdv2ww87wMMN3N2oTywLVz5Nm2a+9gxTJNcotxARydz1BDNfnYvjm3Azp+MhPj6JmEQzNx2ciPX0BCdHwMXy5VMEfGw88bVIXC5dodSNSOrGRtDUw6BK+SK4uZagQikvXKMuUKKaE3W71c3BqxO5czYVLlxcXLh69WqG+27cuJGtAYmIFDSzzsOEs6k2fLIeftoDgF/VEkzs35I+D/rj5KQZtaXwUG4hIoXVlZvxbAm9wc6LsRy5aeZyEkQYjtx0dCLW2ZUELw8Mdzess2A6Y32yw1YuETcoFXGdqsmx+HmYaFjMmZYVPKnTsChentUzPe7o0St3fV0iOcmmwkXz5s1ZsmQJ99xzDyVLlrRuv3btGsuWLaNZs2Y5FqCISH5lGPBKqJkZF1KtQ772J/hpDw38yvDqsDb06FQHR0etUy6Fj3ILESmokpPNnL8Ww8ErcRy4FMvha/EcjzEIc3Alwsub5OJFwKEUeGL5uhPxiZhu3KTYmTD8rlykTJkiOJcrQbmi7tQs7kbjcp40KuGKh5MPtg/DEMn7bCpcjBo1iscee4xOnTrRrFkzSpYsydWrV9mzZw8mk4k5c+bkdJwiIvnO8wdusjgu1YOl3/1C6eC9zJ31fzz+QD0cHFSwkMJLuYWI5FeGYXD2chSbTt9g3d9x/J7gRCSOxDg6Ee/sTLK7G3h7AV6WpznK3sHJk5NxuBmNW1Q0xaKjqB9znRZuyVQtX4Sq5YtQp3ZRShYrhslUHGiQMxcokgfZVLioXr06X3/9NYsWLWL37t1cv34dHx8f2rRpw4gRI6hePfPhRiIihU1ysplBXx5lZZV6/2z8YiPDiiUStG44RX3cMz9YpJBQbiEieVm8GY5ejWPnuZv8Fh7LsZvJnEs0ccXBhWhPT4yiPuDgfWdFCYCkJNwjIikdF0tVpyTqezlQq4gz1Yu54lfCjSpF3XB01GgJkX+zeXHdatWqMXv27JyMRUQk3zv7dwSPBW1hz8MPWreV2r6bb/vXpVVAJTtGJpL3KLcQkdwWnQxbwhPZfimOsMh4wm4mcjbZkSsOZUl0dib5QhxmZ2dwdATcLF/eZL0yR2oJiTjFx+MRF0eRhDjKmJKp6eVIgxKutKvkSePS7jg7aAlRkTtlc+FCREQyl5SUzAdrfuPFr/8gemAPy2ohQLWrl/l9VAAebnc4q5aIiIjYJNmAM5HxHL4cw4WoRMKjE7kam8S1+GQuJZm4ZDgRjhPXHV2IKVYUnG7NdunkDcXu/P1McfF4RkVRKjmeRi7JPFDelWZlPalR0h0v55SZNL2y9yJFCjkVLkRE/gPDMFi95RgvrvuL8yVLw/NP3FqiDCqRwL4HSuOh37QiIiK3lWiGS4kQl2wmJj6J2PgkYuKTOBsRz8kbiYRGJXM+3uBykolrJkduOrkQ6+ZGsocHOLoCrpYTOWKpG9xJ7SApGWLjID4Bx8QknJKT8UiMpyxJVHUzUbeoM03LunNPZR/Ke7liMrlmfweISKaUTouI3KWQ384xeuaPBHfuCD0fTLMv0COZb+u5UFS/ZUVEpBAym81cj07kenQ8N6IT+TsmibMxZs7EmDkbZ+bvRAg3OxJhciLawZG4W8uA4uAAOGCZ1dLlnxM6AkX+a1AGDtcjKX7pElVjb1LF25mqxd1pUsaNYkmXKVnGlYCG/phMpv/4RiKS3ZRSi4jcoYSEJKYs+pnp7+3AKFMSalWx7nPA4LmyJmb7OuKiRUNERCSPSjbgaqKJqwkG4eejiYhNIiIuiYj4ZMLjDa4lGkQnmolLMhOZDBFmBxKTzRiJSSQmmYk1TMTjQLzJRIKDI4mOTiQ6OZHs7EyyizO4uoBTqlEQKTLY9J/cjMY5OgaP+HiKGkl4m8x4O5nwcTLh4+JAWVcTvu4mahdxoUUVH0p4FwWKpjvN0aPRACpaiORRKlyIiNyBs39H8PAr/+O3v66BAfj/s/LBc2UM3qxi0igLERG5a4YBkQnJXIpO5O/oJC7GJHEl3uBKghkjKRmnxEQSE5O5kWRwM8kgKhmizSZizBBlOBDp6MxNR2fiHR1JcHAiwcmJZCcnTMnJOMTGYcZEspsLuLsBtS1veiaDQFKmasgtMXE4RNzAPToGZ8OMk4MJx1tfXiYzpRwNyjsbVPZ0pEYRZ2oVc6NeKQ9KF/XAZPLMxUBFxB4yTa8PHTp0Rydq0EDrCItIwfbz7tP8P3v3HR5F9TVw/Ls1PYGEHkpoCSWU0IvSe1HELoIogqKoNBEFBEEJ+AOktxdQioUiIDYQxAKS0LtIk5YIJCG9bpv3jyVLlgQIsEk2yfk8zz7sztyZvXPZZE/O3PL4wv0kDnwOdDrU876keo9mnL25f1BZSVoIcTcSW4iiRFEg3aJwI9XIjRQjMalGYtNMxKWZiMuwEJthIc5gIc4EiWaFJLOKZEVFhgIZZoU0jZZUvQtGrQ4LYNFosOh0KHodqDVYx0bk4C677kqnxeyax/MymC2oMgxojEa0RiM6swkdoFGrcLOY8DEZ8cNEeT1UdlVR3UtLdR891f3cKFvSDVeXMnlbPyFEoXXHEPuZZ57JVVcpRVFQqVScOnXKoRUTQghnoSgKC77axztbzmJ54znQWX911hj+DBEqPViglBYayg0fIe5KYgtRUBQF0o1m4tNNJKYbSUw3k5hh5u9LaSSaVOjirxJjhDiTQqxZRYJFTYKiIlFRk6yoMVoUTBaFDJUGo1aLSa9DcdHfnI/htrkYAFTYVtIsMBYF0jMg3QAZBtBrwd0NlWJBk25Am5GBJj0dncmIu0aNHgUXlYKrCryx4KWy4K5V4abX4KNVUUoHHnoNWlc9rnoNJV01+LppKemqxc9dSxl3He5aNSpVQV+4EKIoumPiIjQ0ND/rYcdsNrNq1SrWrVvH1atXqVChAi+88AL9+vVDpVKhKAqLFy9m7dq1xMXF0ahRI8aPH0/16re6bBsMBmbMmMGPP/5Iamoqjz76KOPGjaNs2bK2MgkJCYSGhvLbb79hsVjo0qUL77//Pp6esnyREMIqPcPIK9O287VSErIkLQDOKHrrcBGgcwlQy7BYIe6qoGILiSucj8ECyWZINFm4kWbiRrqZG+lm4jIsxGWYiTcoJBgtJJog2ayQYVLIsFjIMCsYzJCiUpOq1mIAzIoKM2BGZX2oVVjUGiwaNYpag6LVgEaTpRdDll4H3r7WfxWsUXF+95rLTC5YLKgsFjQGIxqTCZ3JhN5ixtVswt1swkMx46GYUeu0WFz0aDUq3NXgqQYPDXhqwFurwkenwt9FRUV3NaVdtXi663F30+Hh5o2rixa1OnPyJTcAW3Kwdu3a+XzhQghxf+746/mJJ57Iz3rYWbhwIUuXLuWNN96gYcOGHDhwgKlTp5KWlsbgwYNZsGABS5cuZfTo0fj7+7No0SIGDhzITz/9hJeXFwATJ05k586dvPfee7i7uzNr1iyGDBnCxo0b0Wis/eveeustIiIimDRpEunp6Xz66afExMSwZMmSArt2IYTziLyeSPvPwjjbpSNk6V5b1UXhQoZ9lqJLiXyunBCFUEHFFhJX3D/lZlJWpYIYI/wYY+ZAghmD0YzJaMZsNGEymDAZzBgNRuLNKuIsahLVGpI1Okyo0GQYwGQiQ22dtNF4c9JGi05nWzb61uoROVCR//Ms3IvZAmnpqG8Oh9CZzegsZvSKBRcUXFBwU4ObWsFLpeCtgRJaFSX0Knz1avxc1ZR01eLtpqOsu5bKnlpKeOjR62WcoRBC3E2uf0uaTCbOnTuHwWCwbbNYLKSlpbFv3z7eeecdh1TIYrHw+eefM2jQIIYOHQpAy5YtiY2NZcWKFTz//PMsX76cYcOGMWDAAACaNGlC+/bt2bBhAy+//DKXL19m8+bNzJw5kx49egBQq1YtunXrxq+//kqXLl0IDw9n7969rFu3jgYNGgBQrlw5Bg4cyMmTJ6lbt65DrkcIUTj9GvYvTy09QPzAvrZeFlrFwtsV1EyspKL6IYgx3Srf+WGXaBOiGMqP2ELiCqsMg4mYuFSORqezMVHDH8llSEKD8WoqKpMZjcGA2aJgREWGTofB3Q1FpwOj6bbeCllosN64dyuAC8qJ2QIWi7XOZjMqkxm1xYLaYkZjsaBRFDQWCzpFQYvFmg8xGnCxmPDVafDCgrfKQgm1QkmNgq8OKrhrqeCpw8/bhRJerpTxdsXLwxW12r2gr1YIIYqVXCUujh07xltvvUVUVFSO+9VqtcMSF0lJSfTp04cuXbrYba9atSqxsbGEh4eTmppKx44dbft8fHxo1qwZu3bt4uWXXyY8PByAdu3a2coEBARQs2ZNdu3aRZcuXQgLC8PPz88WXAA0b94cT09Pdu3aVeABhhCiYMQnpjH6019YfjwWhvezJS0e0aTxVUM3Kt3sePFGOZgcYX0e7A7+eTzfmRBFTX7FFhJXQPP/O86+EmXBxxM8b05+mNvRKzoH9QQwWyA9A1WGAbXBgMZoQmsyoTOb0ZutwyLcFAuuWHBXKXioFDw14KUGD60KD50adxcNHnoNHi5a/PRqyriqKemmxdNFi6ebDg83HW6uOlxdXHK9pOWtoRI1HXOdQggh8kSuvo3mzJmDyWTi3Xff5ffff8fV1ZW2bduyc+dOwsLC+Prrrx1WIR8fHz788MNs23/77TfKlSvH9evXAahUqZLd/ooVK7Jz504ALly4QKlSpXB3d89W5uLFi7YylStXttuvVqvx9/e3lblf586dyzJ20HHS0tIAiv0kZdIO0gaZ8qoddu6LZPLSg0RVqQIj+9sC9hYkMN/rP5L/hcx37GTRMFtVnURFQ0dLFKdO3XBoXXJDPg/SBpkc1Q4Wi8UR1cmV/IotintcEZ1qZl/tujcnkbyNRQGDAbTaLEM3sM65kJCM2mBArdehsZjxiviPUtev4a4GFxctelcdLi4a9C469C5afLQKfhoLpTVmyugUPFxU4OKCWq/FVw8+bmpc/TS5SCjc7XotNx9G+80ZkJwByfG5ahI7xf13SHG//qykLayKezsU9+vPyhFt4ci4Itc9LoYPH06/fv1wd3dn69at9OvXj379+jFo0CBWrVrFjBkzHFap261fv549e/Ywfvx4kpOT0ev16PX24yE9PDxITk4GICUlBQ+P7NP7e3h4cO3atXuWyTyPEKJ4sFgUJi89yLpfzkObRtC/ly3Ib65JZqHXVfS3xdql1GY2eF3gokVPC21KAdRaiMKtIGOL4hRXlHbX0PDyFY6VLI/OYMA9PY0qN64RHHOFqhoDZf088fLQoXVzwcNNQwlXLd6+WlzK3ZZkqOMKBBTUZQghhCjmcpW4SEtLs82sXbVqVU6fPm3b99RTT/G///0vb2oHbNmyhYkTJ9K1a1defPFFlixZcsdsfeb2zGXUbpd1u6IoOd7FuNP23KhRowYuLo7vLy4zPltJO0gbZHJ0O4yb/as1adGrDTzRwbb9aT9YXdMTF3WtHI8r6P8F+TxIG2RyVDtkZGRw4sQJR1TpngoqtiiOccVh28dCj3WMSGlOnbKGgPKzU7x/hxT3689K2sKquLdDcb/+rBzRFo6MK3KVuPDz8yM2NhaAypUrEx8fT2xsLL6+vpQoUYIbN/Kmi/QXX3zBtGnT6NChAzNmzEClUuHl5YXBYMBoNKLT3ZpmOiUlxTbzt6enJykp2e+Apqam2pWJjo7OsYwsWyZE0aYoCj//eZZ9xyO5lGDgi0sZMOJFCK5hK/NmOZhTFTSyxKkQeaIgYguJK4QQQojCKVe3AJo3b86yZcu4evUq5cuXx8/Pj++//x6A33//HV9fX4dXbNasWYSGhvL4448zd+5cWxfOKlWqoCgKERERduUjIiKoWrUqYJ0wKyYmhvT09LuWuXLlit1+i8VCZGSkrYwQouiJT0zj2ZHr6Tn0az46nswXzdvCwMfskhYfV4Z5krQQIk/ld2whcYUQQghReOUqcfHmm28SGRnJiBEjAOjfvz+hoaE88sgjrFq1ip49ezq0UitXrmTJkiUMGDCAadOmodXe6hgSEhKCi4sLO3bssG1LSEhg3759tGzZErAuc2Y2m22TagFcvHiRs2fP2pWJjo7m2LFjtjJ79+4lOTnZVkYIUbSEH7lCSN8lrN8bAaMHwEu9wd3Vtr+UVuHzGjCuIuRyQnohxAPKz9hC4gohhBCicMvVUJEqVaqwdetW2ziX1157DbVazYEDBwgJCWHw4MEOq1BUVBQzZswgMDCQnj17cvToUbv9wcHBvPjii8yZMwe1Wk1AQACLFy/G09OTp59+GrB2Oe3WrRsTJkwgOTkZb29vZs2aRVBQEJ06dQKgRYsWNGjQgGHDhjFmzBhMJhPTp0+nXbt2BAcHO+x6hBAFL8Vk4ektl9gafgGlVhD0bgtet1YH6KBOYVJtd1p5q6SXhRD5JL9iC4krhBBCiMIvV4mL/fv3U7t2bVq1amXbNnjwYAYPHkx8fDzbtm2jR48eDqnQ7t27MRgMnDlzhmeffTbb/rCwMEaOHIlarWbFihWkpqYSEhLCtGnTbONMAUJDQwkNDWXGjBlYLBZatWrFuHHj0Gisy32pVCoWLVrElClTmDBhAnq9no4dO/LBBx845DqEEM7halQSDbffIKpqVehj3127gh7+rzr0KJl9JQAhRN7Kr9hC4gohhBCi8FMpiqLcq1Dt2rX56quvCAkJybZvz549DB06NNsdjOIkc7bU4OBgWVUkD0k7SBtkym077Dl8ma5fnSH5iU7Z9nUtAatrQmld9uMKC/k8SBtkcvSqInn1fZaVxBZ3lh//D/KzY1Xc26G4X39W0hZWxb0divv1Z+XIVUUc8X12xx4X77//PjExMYB1Bv7p06fb3XnIdO7cOXx8fB6qEkII4Wj/Xoml+7Q/SH7jedu2fuYb1KvqR6AbPO4LahkWIkS+kthCCCGEEA/ijomLpk2bMn/+fMDa/TEiIsI2A3cmjUaDr6+vQ+e4EEKIB5VhMHHibBSp6Sae2XKBxDeeB53119xL3ga+CPYr4BoKUbxJbCGEEEKIB3HHxEXfvn3p27cvALVq1WLu3Lk0atQo3yomhBC5ZTZbmL/5OBNOJJFUsxqULwddK9v2N3Yzs7iO/i5nEELkB4kthBBCCPEgcjU55z///GN7bjKZSEtLy7FrpxBC5Cez2cKarX8z6u90bjSuD52zJyeec0tjRX03XHO1+LMQIr9IbCGEEEKI3MpV4gKsAcb06dPZv38/ZrMZjUZD8+bNGTVqFHXq1MnLOgohhB2z2cLmvyJYsvg8Ee1aQmv7ISCeaamUSk3hncoahjfwLaBaCiHuRWILIYQQQuRGrhIX586d4/nnn0er1dKzZ09Kly7NtWvX+P3333nhhRfYsGEDNWrUyOu6CiGKuZi4FD79+QzzDCVIr90J6mls+1RmC900ycwO8SbQzR1wL7iKCiHuSWILIYQQQuRWrhIXc+bMoUyZMnz99df4+t66exkbG8sLL7zA/PnzmT17dl7VUQhRjKWlG1n3+zlWhF1md4YLlu6P2CbczFRTSWd9iAsNPL0LqJZCiPslsYUQQgghcitXo7737dvH0KFD7QILAF9fX1577TX27t2bJ5UTQhRPZrOFb/+6wKMLDuD11RUGegbxZ9euWB5rZ0taaJNT6KQksrqGwt+tXGngKWubClGYSGwhhBBCiNzKVY8Lk8lEyZIlc9xXsmRJUlJSHFopIUTxoygKfx3/j3GHE9jj5oupQgCEVM2xbK+Mq0yqmEDjOrXyt5JCCIeR2EIIIYQQuZWrxEX16tXZsWMHbdu2zbZv+/btBAQEOLpeQohi4vSFGL7+6QSLrpiIeqQZ1PTPVsY9NZWWrkbaV/aiu68atyvx+V9RIYRDSWwhhBBCiNzKVeKif//+vPvuu6jVap544gnKlClDVFQUGzduZOPGjYwfPz6v6ymEKCIUReHoP9f4dvspNvx+jn/iDPBcV3ispl05z/h4WrmaeKeuD93KuKPOMhLkVD7XWQjheBJbCCGEECK3cpW46N27N8ePH2f16tWsW7fObl+/fv3o169fnlROCFH4KQocS1FY8nc84ZcTOROTRoqnJ9RpBU06ZCtfJzWez2q70KVVifyvrBAi30hsIYQQQojcylXiAuCDDz7ghRdeIDw8nPj4eEqUKEGLFi2kK6cQws6NDAsrzyXz+w0TUWj516IjWu8GlIQKJaFCzsf5qS0sq6mmj1+J/KyuEKIASWwhhBBCiNzIVeJi/vz5PPXUUwQEBGQLJq5cucIXX3zBhAkT8qJ+QggnZrFY+OdiLJv/ieXnWIVjrj4kli0DGu97/nbxMWVQ00NDBXctQW4wuoKaMvr8qbcQouBJbCGEEEKI3MpV4mLBggW0bt2acuXKZdt37Ngx1q1bJ8GFEMXAudg0/joXx8FLcfwWZeC03gtjgD+UKAUl7nCQRYELEVSOjODpWiXp1bQyIWXd8dG65GfVhRBORmILIYQQQuTWHRMXzz33HKdOWafAUxSFl156CZVKla2cwWCgZs2a2bYLIQovk8nMr+fj2HI5nVOx6ZxPU/jPtxSmUiUBN/CvANkX/wBAE5dApajrNFWl4W9Ox08x0bV5AE37t8zXaxBCOB+JLYQQQgjxIO6YuHjvvfdYt24diqKwefNmWrRogZ+fn10ZtVqNt7c3Tz31VJ5XVAiRN+IS0gg7dZ1tFxPZF2vmvEVLTJkyKBXLggfWx11oDQaqpSXS2sPCgGrutG3pg0rlky91F0IULhJbCCGEEOJB3DFxERISQkhICACRkZG8++67cvdDiEIsw2Di9IUYjp6L4fsYC2E6H6J0Lhjc3ME3ACpjfdyJxYJHVAzlzRmU99TRpJQLLwR6E+KtR6MqlU9XIYQozCS2EEIIIcSDyNUcF6tXr87regghHkBqmoGr0clci0nmQnQyRxIt/JdsIi0+mdTYJJJvJHIjLo2r7p4kli4FARWgenWo6XbPc/vExlI/PYFGvjqa+HvRI8ALX5cy+XBVQojiQGILIYQQQuRWrpdDFULkD7MCu24Y+eLfVI4mKyQbLaSaFIyoyDCXxmQyYzl+DYNajcXVBbQuoHIBj0rglX2s+L1o0tIpYUinhsZE0xJaOlZ2p6WvnrJ6X8DX8RcohBBCCCGEEPdBEhdCPCSLxUJ8hpnEDDMpBjMJBgtRGRYSjQpGoxmTyYLBZMZgtJBuVki9+W+ayUJMupmYdDOxBoUEk8IND0+Sy5RGcXUBfMAV68OB9GYTDS2p9C9l4aUaXni55MGbCCGEEEIIIYSDSOJCOA1FATNgtIAJMFoU0o0W0s0W0o1m/klUSDfD1ctJpJut+9LMFm6YVMSYQG1W0FtMWCwKGWaFNLNCugXSzQopJgtpJoVUs0KaGdIVFQYgAxVG1KhMJjTpGZgtCga1BqNag1GtxqjRYNJoMWu1mHVaLDotik6HotWCyQQZBnDRWx/o7n2RmpuPTA8zh6XZjNZgRGexoNGo8FTMBCgZ+OtBcdVj1OnJ0Goxq9TUcVfR1BOaekKgmxa1yvsh3lgIIYQQQggh8k+xT1ysW7eOZcuWce3aNWrXrs3YsWNtE4cVdhYF/stQiEwyEJOYTmK6EYNJId2ikGGy/nFvsEC62YLBAhkWhWhFSzRa1BYLniYDaosZkwVMFgWTwq2HRcF887lZuZloQE2GWk26oiIdFUaNBrNWh0UFKrMFRVGwqDUoajUWjRpFq0FRa27+qwat5rYrUHHrL30dUMe6OSIXF68i7z/dmsyEhWOpklLwvBZFndR42nkp1Cztjr+vO74eOmKuXqGElwuNG9dHr9agUt3eZp4Or48QQoj7U5RjCyGEEKIgFOvExebNm5k4cSJvvvkm9erVY/Xq1QwaNIjvvvuOSpUqFUid9kcmMTQsjmhFjQUVFsBg9sCCCvXJq1hUKut2FSgqtfVfVFjUKhRUKCoVilqNolJh8nQHrRZwufm4g9t7AYjszBYwGFAZjKiNJtQmE+i0KHo9GpMJXXo6OpMJDaBVzLgajbgoFjRqlfWhUaNRq3BRgU4FLmrQq1X4uqop666jgpeOSj4uBJdyJdDTA5Wqao7VOKWKB8BFc/9zWQghhMh7zhhbCCGEEIVdsU1cKIrC3LlzeeaZZxg2bBgArVq1olu3bqxcuZLx48cXSL1e/CuWMxWrFMh75wmLxdr1I7M3hclsfZhNqExmVGaL9V+LBZViQW2xoLYoqBULKkVBDagVBY2ioJhNqBULLloNGkVBC2hRcDUZcTcZUWvUmPR61GoVehT0KtCrFFzU4KFV46FT46lX46lV46lT4aFV4anT4K5ToWi1pGu06LVqfPS3HiVdtZR00aBXq1Gp7jYXxMOM+RBCCFEUOGtsIYQQQhR2xTZxcenSJSIjI+nQoYNtm06no127duzatavA6tXC3cIZswU06vs70GS2ThJhsdiSBZrUNNySknA3mXDVqnHRYPtjX6u6+S+gU1u361TgoxjxMxtRadSk6l1Ao0F7s3eAVq1Cpwa9Ro1Oo0KvVtn966mxJgP83LWU8dTj56bFU6tGp1OjUVtQqVVo1JndO+5/iMWpU6cAqF27xn0fK4QQQuQ1Z40thBBCiMKu2CYuLl68CECVKva9GypVqsTly5cxm81oNLkbP6EoCgBnzpxBrb7PhMNtxlSFZxOOcT3VglZtTSZYTAa0ajWebnprgkFjTSBY96vQalWoVSrUakcNH8i8howHOzzD+riB9eEo6enpAJw8edKBZy1cpA2spB2spB2kDTI5qh0sFgtw63tN3B9HxRaOjCvuRH52rIp7OxT3689K2sKquLdDcb/+rBzRFo6MK4pt4iI5ORkADw8Pu+0eHh5YLBbS0tLw9MzdRIdGoxEAg8HgkLqVdbE+bslcrcKcvbACJqND3rbQyPwhKs6kDaykHaykHaQNMjmqHYxGI66uskzy/XJUbOHouOJu5GfHqri3Q3G//qykLayKezsU9+vPyhFt4Yi4otgmLjKzPiqVKlfb78bDw4PAwEB0Ot19HSeEEEI4E0VRMBqN2f7wFrnjqNhC4gohhBBFgSPjimKbuPDy8gIgJSWFUqVK2banpqaiVqtxd3fP9bnUarXtfEIIIURhJj0tHpyjYguJK4QQQhQVjoor8mbgZCGQOf70ypUrdtuvXLlC1apV5Q6HEEIIIe6LxBZCCCFE3ii2iYuAgADKly/Pjh07bNuMRiO///47LVu2LMCaCSGEEKIwkthCCCGEyBvFdqiISqVi8ODBTJkyBR8fHxo1asSaNWuIi4tj4MCBBV09IYQQQhQyElsIIYQQeUOlFPM1z1asWMGqVauIi4ujdu3avPfee4SEhBR0tYQQQghRSElsIYQQQjhWsU9cCCGEEEIIIYQQwnkV2zkuhBBCCCGEEEII4fwkcSGEEEIIIYQQQginJYkLIYQQQgghhBBCOC1JXAghhBBCCCGEEMJpSeLiAZnNZj7//HO6d+9Ow4YN6dGjB2vWrCFzrlNFUVi0aBHt2rWjQYMGvPzyy5w/f97uHPHx8UyaNIn27dvTqFEjnn32WcLCwuzKJCQkMHbsWJo3b07Tpk0ZN24cycnJ96xfbt5/69atBAUFZXusWbOm2LUFwOrVq+nSpQv169end+/e/PTTT8Xi+ufNm5fj5yAoKIgOHTrkqg2KQjtknnv8+PE88sgjNGvWjKFDh3LlypVct0FRaotLly4xdOhQQkJCaNGiBR988AFxcXFF4vqzWrlyJb169cq23WAwMHXqVFq3bk1ISAhvv/02169fv69zQ9Foi0zDhg1j8uTJ93VOcX+c/fOSX7FFUWgHkLjiYeOKotAWmed+2NiiKLSDxBUSV9zuvuMKRTyQuXPnKsHBwcrChQuVPXv2KHPnzlVq166tLF26VFEURZk3b55Sr149ZeXKlcqOHTuUJ598UnnkkUeUxMRERVEUxWKxKP3791ceffRR5dtvv1V27dqljBgxQqlVq5Zy6NAh2/v0799fad++vfLTTz8pGzduVFq0aKEMGTLknvW71/sriqLMnj1b6dy5s3L48GG7R3R0dLFri6VLlyp16tRRlixZouzZs0cZP368EhQUpISFhRX567969Wq2z8C3336rBAUFKQsXLrzn+YtKOyiKorzyyitKy5YtlU2bNik7d+5U+vTpo7Rv315JTk7OdTsUhbaIjY1VWrdurXTo0EH57rvvlF9//VV56qmnlF69eikZGRmF/voz/fLLL0rdunWVnj17Zts3duxYpVmzZsq3336r/Pzzz0rnzp2Vxx57TDGZTLk+f1FpC4vFokyfPl0JDAxUPvroo/u6fnF/nP3zkl+xRVFoB4krHj6uKAptoSiOiS0KeztIXCFxRVYPGldI4uIBmM1mJSQkRPnss8/stk+aNElp0aKFkpSUpDRs2FBZsmSJbV98fLwSEhKirFixQlEURTl69KgSGBio7Nmzx+68vXr1Ut5++21FURQlLCxMCQwMVI4cOWIrs2fPHiUwMFA5ceLEHeuXm/dXFEUZOnSoMnz48AdrhCx1LuxtkZSUpDRo0EBZtmyZ3bH9+vVTZsyYUeSv/3Ymk0l54oknlBdffFGxWCx3vf6i1A4xMTFKYGCgsn79eluZf//9VwkMDFR+/vnnXLVDUWmL5cuXK0FBQcq5c+dsZW7cuKE0bNhQWbNmTaG+/sw2mDZtmhIUFKQ0bdo025fqpUuXlFq1aik//vijbduFCxeUoKAgZdu2bXc9d1Fri8uXLytDhgxR6tWrp9SvX18SF3nI2T8v+RVbFIV2kLjC3oPEFUWlLRwRWxSFdpC4QuKKTA8TV8hQkQeQlJREnz596NKli932qlWrEhsbS3h4OKmpqXTs2NG2z8fHh2bNmrFr1y4A1Go1Tz/9NI0aNbKVUavVVKlShYiICADCwsLw8/OjQYMGtjLNmzfH09PTdp6cHD169J7vD3D69GmCgoIesBWsikJb7N69m4yMDJ5++mm7Y9esWcOoUaOK/PXfbv369Zw+fZoPP/wQlUp11+svSu2QkZEBgKenp61MiRIlAGt3udwqCm1x8eJFKlSoQPXq1W1lfH19qVat2l3PXRiuH2DDhg18//33zJgxI8duy+Hh4QC0a9fOti0gIICaNWve89xZFYW2CA0NJTo6mq+//ho/P79cX7u4f87+ecmv2KIotIPEFfYeJK4oKm3hiNiiKLSDxBUSV2R6mLhCEhcPwMfHhw8//JA6derYbf/tt98oV66cbbxSpUqV7PZXrFiRixcvAhAcHMzHH3+Mi4uLbX9ycjL79++nWrVqAFy4cIHKlSvbnUOtVuPv7287T04y993t/VNSUoiMjOTvv/+ma9eu1K1bl969e/PHH3/kqg0yFYW2OH36NKVLl+bUqVM88cQT1K1bly5durBt27Zicf1ZZWRkMH/+fJ588klq1qx5x/Perii0Q4UKFWjfvj2LFy/m/Pnz3Lhxg48//hhPT0/atm2bq3aAotEW5cqVIy4ujvT0dNt+k8nEtWvXiIyMLNTXD9CxY0d27Nhxx3GXFy5coFSpUri7u9+xjrlRFNpixIgRfPvtt9StW/ee1ysejrN/XvIrtigK7SBxxS0PGldA0WgLR8QWRaEdJK6QuCLTw8QVkrhwkPXr17Nnzx5effVVkpOT0ev16PV6uzIeHh53ndTko48+Ijk5mZdffhmwBgAeHh7Zyt3rPLl5/9OnT6MoChEREYwdO5ZFixbh7+/P66+/bssKPqjC1haxsbGkpqYycuRInnrqKZYtW0ZwcDDvvPMOhw8fzvV1Zyps15/Vjz/+yI0bN3jllVfueo25URjbIXPioR49etCqVSu2b9/O/PnzKVeuXK6u+U4KW1t069YNk8nEmDFjiIyMJDo6mo8++ojExETS0tJyfd2ZnOn6wfqF7urqesf9D3PueylsbVGzZs37ukMqHMuZPi8FGVsUtnaQuOIWR8YVUDjbIi9ii8LWDhJXSFyR6WHiCklcOMCWLVuYOHEiXbt25cUXX0RRlDv+h+S0XVEUPvroI7Zs2cLYsWNtWbQ7nUdRFNRq63+dyWSyeyjWeUvu+f41atRg6dKlrFq1ivbt29OmTRsWLFhA9erVWbRo0QO1AxTOtjCZTCQlJfHuu+/Sr18/WrZsyYwZMwgMDGThwoVF/vqzWrduHW3atCEgICC3l5yjwtgO169f59lnn8XNzY25c+eyYsUK2rdvz5tvvsmRI0cepBmAwtkW1apVY9asWezbt48OHTrQpk0bTCYTHTp0wM3NrVBff27c7dwP80d8YWwLUXCc7fNSULFFYWwHiStucVRcAYWzLfIitiiM7SBxhcQVjqDN83co4r744gumTZtGhw4dmDFjBiqVCi8vLwwGA0ajEZ1OZyubkpKCl5eX3fEGg4ExY8bw888/M2rUKPr372/b5+npSXR0dLb3TE1NtY2Vu72bTWhoaK7e39vbO1sXNY1GQ6tWrfjuu++KVVtkdtt69NFHbfvVajUtWrTIVbfOwn79mWJiYjhy5AjTp0/P9TXnpLC2w7fffktiYiKbNm2ibNmyALRq1YrnnnuO//3vf3z55ZfFpi0AOnfuTIcOHbh8+TI+Pj74+vrSv39/fHx8CvX19+3b95719vT0JCUlJcdz317H3CqsbSEKhjN+Xgoitiis7SBxhZWj4goovG3h6NiisLYDSFwhccXDk8TFQ5g1axZLliyhT58+fPLJJ2i11uasUqWKratk1apVbeVvf52ens7rr7/O3r17mTRpEs8//7zd+QMCAjh06JDdNovFQmRkJL179wasE6BkVbFiRU6ePHnP9//77785efJktomj0tPTKVmyZLFqiypVqgBgNBrtjjeZTLnOghbm68+0e/duNBqN3YQ+96swt8O1a9coV66cLbAAa3a6UaNGbNy4sVi1RWRkJGFhYTz11FO2bRaLhbNnz951Pe7CcP25ERAQQExMDOnp6XbdHSMiImjcuHGuzpFVYW4Lkf+c9fOS37FFYW4HiSusHBFXQOFuC0fGFoW5HSSukLjCIXJaakTc2xdffKEEBgYqH3/8cbalnZKTk5V69erZ1tNVlFtL0Sxfvty27c0331Tq1KljtzROVpnLzhw9ejTbtuPHj9+xbrl5/w0bNiiBgYHKyZMnbWXS0tKUtm3bKhMmTMhlK1gV9rbIXJbq888/t5UxGo1Kly5dcrWkW2G//kwfffSR0qtXr3te750U9nZYvny5UqdOHeXq1at2xz7//PNK3759c9ECtxT2tjh48GC2Ja9++OEHJTAwUPnrr78K9fXf7r333stx2bLAwMAcly3bunVrrs+tKIW/LbJq3769LIeax5z585KfsUVhbweJK6weNq5QlMLfFo6KLQp7O0hcIXFFTu43rpAeFw8gKirKNlaxZ8+eHD161G5/cHAwL774InPmzEGtVhMQEMDixYvx9PS03YXYvn0727dvp0+fPlSoUMFunJurqyu1atWiRYsWNGjQgGHDhjFmzBhMJhPTp0+nXbt2BAcH37F+Hh4e93z/bt26sXTpUt555x1GjBiBi4sLy5cvJzU1laFDhxartqhatSpPPvkks2bNQlEUatSowddff01kZCRz5swp8tef6ezZs9nuluRWUWiHJ598kpUrVzJ48GDeeOMNPD092bx5M4cOHWLBggXFqi0aNGhAnTp1GDduHCNGjCAqKoqpU6fSpk0bWrVqVaivPzcqV65Mt27dmDBhAsnJyXh7ezNr1iyCgoLo1KlTrs9TFNpC5B9n/7zkV2xRFNpB4gqrh4krikpbOCK2KArtIHGFxBWOoFIUmaHrfm3cuJH333//jvvDwsLw9vZm9uzZbNq0idTUVEJCQhg3bpxt/eKxY8eyadOmHI+vWbMmP/zwAwA3btxgypQp/PHHH+j1ejp27MgHH3xgtx50Tkwm013fH+Dq1av873//s63527hxY9577z0CAwOLXVuYTCYWLlzIt99+S1xcHLVq1eLdd9+ladOmxeL6AXr06EGjRo34+OOP73q+nBSVdoiMjGT69Ons2bMHRVGoVasWb7/9Ns2bNy92bfHff/8xZcoU9u3bh7u7Oz169GD48OH3nESrMFx/VmPHjuXEiRO2c2ZKTU0lNDSUbdu2YbFYaNWqFePGjbPr7nsvRaUtMnXo0IF27drx4Ycf5vqcIvcKw+clP2KLotIOElc8XFwBRactHja2KCrtIHGFxBW3u9+4QhIXQgghhBBCCCGEcFqyHKoQQgghhBBCCCGcliQuhBBCCCGEEEII4bQkcSGEEEIIIYQQQginJYkLIYQQQgghhBBCOC1JXAghhBBCCCGEEMJpSeJCCFFoyaJIQgghhHAkiS2EcE6SuBBCFLigoKBcr+Gc6V5rWQshhBCi+JLYQoiiRRIXQohCaf78+URHRxd0NYQQQghRREhsIYTzksSFEEIIIYQQQgghnJYkLoQQ+WrNmjV069aNevXq8fjjj3Pw4EG7/cnJyXz66ae2Mg0aNKBv37589913tjJBQUFERkaye/dugoKC2Lt3LwCpqalMnz6d9u3bExwcTOfOnVmyZAlmszlfr1EIIYQQ+UdiCyGKPm1BV0AIUXzMnz+fefPm8cwzz/D+++9z+vRpXn/9dbsyQ4cO5cyZM7zzzjtUrVqVmJgYVqxYwXvvvUetWrUICgriyy+/ZPjw4VSoUIExY8YQFBSE0WjklVdesZ2zVq1aHDx4kDlz5nDx4kVCQ0ML6KqFEEIIkVckthCieJDEhRAiXyQnJ7N06VK6devGlClTAGjbti2lS5dm7NixAERHR6MoCpMmTaJ79+62YwMCAnjqqacICwsjKCiIJk2aoNfr8fLyokmTJoB1Qq3Dhw8ze/Zs27Ft27bF19eX0NBQnn/+eerXr5/PVy2EEEKIvCKxhRDFhwwVEULkiyNHjpCRkUHXrl3ttvfq1Qu12vqrqHTp0qxZs4bu3bsTGxvL4cOH+e677/jqq68AMBgMdzz/X3/9hVarpX379phMJtujW7duAPz55595dGVCCCGEKAgSWwhRfEiPCyFEvoiLiwOgVKlSdtt1Oh2+vr621zt27GD27NmcPXsWNzc3qlevTs2aNe95/tjYWEwmEw0aNMhx//Xr1x+i9kIIIYRwNhJbCFF8SOJCCJEv/Pz8ALItM2axWEhISADg0KFDvP322/Ts2ZMFCxZQuXJlVCoVZ8+eZdOmTXc9v7e3Nz4+PixfvjzH/SVLlnTAVQghhBDCWUhsIUTxIUNFhBD5IiQkBHd3d7sZvAF27tyJ0WgErMGF2Wzm9ddfp0qVKqhUKlsZsAYimTK7gGZq1aoVCQkJqFQq6tWrZ3uYTCY+/fRTzp8/n5eXJ4QQQoh8JrGFEMWH9LgQQuQLNzc3Ro0axZQpUxg1ahS9e/fm8uXLLFy4EJ1OB0DDhg0BmDp1KgMGDADg119/ZcOGDQCkpaXZzuft7c25c+f466+/qFOnDn369GHt2rW89tprDB48mMDAQC5evMi8efNwdXWVybOEEEKIIkZiCyGKD5WiKEpBV0IIUXxs3ryZ5cuXc/HiRfz9/RkxYgSffPIJ7dq1Y/LkyWzcuJFly5YRERGBl5cXNWvWZMiQIUybNg0PDw++/vprAH7++Wc++eQTEhISCA0NpVevXiQnJzNv3jx++eUXoqOj8fX1pXXr1rz99tuUL1++gK9cCCGEEHlBYgshij5JXAghhBBCCCGEEMJpyRwXQgghhBBCCCGEcFqSuBBCCCGEEEIIIYTTksSFEEIIIYQQQgghnJYkLoQQQgghhBBCCOG0JHEhhBBCCCGEEEIIpyWJCyGEEEIIIYQQQjgtSVwIIYQQQgghhBDCaUniQgghhBBCCCGEEE5LEhdCCCGEEEIIIYRwWpK4EEIIIYQQQgghhNOSxIUQQgghhBBCCCGcliQuhBBCCCGEEEII4bQkcSGEEEIIIYQQQginJYkLIUSOxo4dS1BQUK4ee/futR334Ycf2rYPGjQoV+ePjY1lxYoVttcbNmywK7t7926799u9e7fd/i+++MK278cff7Tb98MPP9j2NWnShPT09Bzrs3fvXlu5p59+GkVRspXJ3D927Nh7tp8QQggh7N0eW7z99tvZygwdOtSuTOZ3bm7jkk8++QSA+fPn27a99NJL2d7nq6++su1/7rnnUBTFLhZYvnx5tmNiY2P57LPPeOyxxwgJCaF+/fp069aNqVOncu3atTte99WrV5k+fTq9e/emcePG1KtXjw4dOjB69GgOHDjwoM0pRLEiiQshhMOkp6fz008/2V7/9ddfRERE5OrYxo0b254fO3bMbl9YWJjd6/3799u9zlq+SZMmdvu+/fZb2/OkpCS2bt16z7ocO3aMjRs33rvSQgghhHhge/futbtRYLFYOHjwoEPOPWTIEGrUqAFAeHg433//vW1fbGwss2fPBkCn0zF58mRUKtVdz3fgwAG6d+/O4sWLOX36NKmpqWRkZHDhwgVWrlxJ7969c0xC7Nixgx49erBixQrOnDlDcnIyBoOByMhIvv/+e/r168ekSZMwm80OuW4hiiptQVdACOGc3n//fYYPH257/fnnn/PFF18AsHTpUoKCgmz7fH19Adi6dStJSUm27YqisGHDBrvz3EmdOnVwc3MjLS2No0eP2u27PXGxb98+u9eZ5StWrEjZsmVt2//77z/Cw8Ptyq5bt44+ffrcsz4zZ86kS5cueHl53bOsEEIIIe5ffHw8p06dok6dOgCcOnWKhISEex63ZcsWfHx8ctzn4eEBgF6vZ/LkyfTr1w9FUZg+fTrt2rXDy8uLGTNm2N7nlVdeITAw8K7vd+XKFV577TWSk5Nxc3Pjrbfeol27dqSlpbFu3TrWrl1LYmIib731Fr/88ostdjh69CjDhw/HaDSi0+kYNGgQXbt2xcPDg5MnTzJnzhwuXrzI119/jZubG++9916u206I4kZ6XAghcuTj40O5cuVsD09PT9s+X19fu316vR7A1kvBw8ODUqVK2bbl5i6CTqejXr16AJw9e5bU1FQAEhISOHXqFICtDsePH7cN+YiNjbX16ri9t8XGjRuxWCwAVKlSBYCDBw9y/vz5e9bnxo0bzJs3757lhBBCCHH//P39AexuMGQOPc3cdyelS5e2i0OyPrLecGjcuDHPPvssANHR0cyePZsjR47Y4pXKlSvzxhtv3LOun332GcnJyYD1xsagQYOoXr06wcHBTJ48mSeffBKAuLg4fv31V9txH3/8MUaj0XbciBEjqFOnDlWqVKFHjx6sW7eOihUrAtZhrxcuXLhnXYQoriRxIYRwiCtXrth6QnTq1Inu3bsDcP36df78889cnSNzuIjZbObkyZOANYjJTD68/PLLABiNRg4fPgzAkSNHbMdnTVwoisKmTZsAqFChAqNHj7btu30Ojdtldhf98ssvOXfuXK7qLoQQQojcy/zOzilx0bRpU4e9z7vvvkuZMmUA+Prrr3n33Xdtw1MmTZqEq6vrXY9PS0vjl19+ASAwMJCOHTtmK/PGG28wb9489uzZY+vVefnyZdtQ1pCQELp27ZrtOB8fH15//XXAOkxm8+bND3SNQhQHkrgQQjjExo0bbYFAz5496d27t23f+vXrc3WOrPNcZA7/yBwm4uPjw0svvYRWax3hljnPRdZhJVmPDw8Pt/XE6NGjB+3atcPb2xuAzZs3YzAY7liPxx9/HACTycTHH3+cq7oLIYQQIvcykxMHDhzAZDJhNpttc0TcK3ERHR3NtWvXcnzcPrm2p6cnH374IWC9MXL58mUAevfuTevWre9Zz5MnT9p6TTRs2DDHMhUrVqRLly62obMAhw4dsj1v1arVHc/fokUL2/PMmzJCiOxkjgshxEPLepegZMmStG7dGq1WS+XKlbl8+TJ//PEHUVFRtjsedxISEoJGo8FsNtvuUmQmLpo1a4aXlxf16tXj8OHDtsRFZjk/Pz+qVatmO1fWSTl79eqFXq+nc+fOfPvtt8TGxvLrr7/aeoXcrnnz5mRkZPDzzz8TFhbGtm3bcrxTIoQQQogHk5mcSElJ4dixY2i1WttwjHslLh577LE77tu/f7/tRkWmzp0707x5c1uPDnd3dz744INc1TM6Otr2PGti4l5u3Lhhe551/q3bZd2X9RghhD3pcSGEeGhhYWH8999/AHTt2tXWK6JXr16AtedC5rCNu/H09LRNkHX06FGuX79uG+/ZsmVL4NadiSNHjpCens7x48cB+2EiycnJbN++HYBq1apRu3ZtALteIPcaLjJ27Fjc3d0BmD59+h2XURVCCCHE/QsICLDd0AgPD7cNGSlTpoxtXipHiYiIsMULAKmpqXav7yZzuCqQ41Lpd5J1fq+7Hfeg5xeiuJHEhRDioWXt3VC6dGn+/PNP/vzzT7s7E+vXr8/VF3LmcI9r167ZjfXMTFhkJjAMBgObNm2yrWKSdZjIDz/8YEs01KxZ01Yfg8GAm5sbcO+lWsuVK2cbdxoZGcn//d//3bPuQgghhMi9rPNc3M/8FmFhYZw+fTrHx+29LQAmTpxom/Q706RJk2w9PO4maywTExOTYxlFUbLFOH5+frbnV69eveP5s+7LeowQwp4kLoQQDyUxMZEdO3bYXs+bN4/BgwczePBgu/khrly5km1p0pxkTUCsXLkSsCZDqlevDliHk2ROpPX555/bymbtcZE1kbJt2zZbfYYMGUJaWhpwa6nWu3n55ZcJCAgAYNmyZfesuxBCCCFyLzNJceTIEducEI6cmBOs81rt3r0bsM5F0alTJ8C6ZPqMGTPueXxwcDBqtfVPptuXa8+0e/du2rZty+TJk20roWWdD2PXrl13PH9m3W4/RghhTxIXQoiH8v3335ORkZGrsrmZpDNr4iJzrGfWiav0er2tzKVLlwDr8qu1atUC4Ny5c7Z5L+7lXku16vV6xo0bByBDRYQQQggHy0xSZGRk2HpEODJxERsbS2hoqO31pEmTmDRpkq1XxjfffGObM+tOvLy8aNeuHWCNMX777Te7/Yqi8Pnnn3P9+nW+/PJL2xDX6tWr25Z5P3nypN1NlUwxMTEsWbIEsK5olrkiiRAiO0lcCCEeStYv4u3bt2frsnn48GE8PT1t++Pi4u56vrJly2Zbvz1zeEimrIkMuDWp5+31+eSTT3LsRpp5fG6Wam3Tpg0dOnS4axkhhBBC3L8aNWpQsmRJ22tfX19bD8u7uduqIlknuPzkk0+Ij48HrPNuPfroo5QuXZpRo0YB1qTD+PHj73kDZvTo0bZ5r0aOHMnKlSu5cOECR44cYfjw4fz111+AdbnUrJN5jxs3Dp1OB8CECROYPn06J0+e5NKlS3z33Xc888wztsk/BwwYkKtrF6K4ksSFEOKBnT59mpMnTwLWOySVK1fOVsbd3d02KabBYOC7776753mz9rqA7ImK2xMZmcNETCYTW7Zssb1vt27dcjz/s88+a3uem14gH3zwAS4uLvcsJ4QQQojcU6lUdkM9mzRpgkqluudxjz32GG3bts3x8corrwDwxx9/8MMPPwDWJdXff/992/HPPvssjRo1AuDixYvMnTv3ru9XvXp1Fi5ciJeXF6mpqUydOpVu3brx7LPPsnXrVgDKly/P3LlzbTdSwHpjZfbs2bi7u2M2m1mxYgV9+/alS5cujBkzhsjISACefvppxowZk5smE6LYksSFEOKBZe3d0Ldv3zuWe+6552zPc5MoyBrEVKpUKVsPjLp16+Lj45Ot/O+//26bOKtr1662nh6369y5s20CrMylWu+mUqVKDB48+J71FkIIIcT9yTo0JOv3/8NISUlh0qRJttfvvvsupUqVsr1WqVRMnjzZ1hvi888/v+cqIy1btuSnn37i5ZdfpmrVqri4uODi4kJgYCBDhw5ly5YtVK1aNdtxnTp1YuvWrQwePJigoCA8PDzQ6XSUK1eOnj17smrVKj7++GPbimxCiJyplCK87o7BYGDBggVs2bKFuLg46tevz3vvvUfdunUBa/ewxYsXs3btWuLi4mjUqBHjx4+XblpCCCFEEZJ5p3PdunXExMRQo0YNRo4caeu9lZt4wGAwMGPGDH788UdSU1N59NFHGTduHGXLlrWVSUhIIDQ0lN9++w2LxUKXLl14//3375hEFUIIIUTuFOkeF6GhoaxevZrBgwczf/583NzcGDBggK1b1oIFC1i0aBGvvPIKs2bNIikpiYEDB9qWVxRCCCFE4bd8+XI+++wznnzySRYsWEDlypUZPHgwf//9N5C7eGDixIl89913jBo1itDQUP755x+GDBliN8HvW2+9xb59+5g0aRIffPABO3futI2lF0IIIcSDK7I9LpKSkmjZsiWjRo3i5ZdfBqyrAjRv3pzXXnuNAQMG8OijjzJ06FCGDBkCWO+UtG/fnrfeest2jBBCCCEKt+7du1OvXj0+/fRTwNoDo2PHjnTo0IGRI0feMx64fPkyXbt2ZebMmfTo0QOwjovv1q0bc+fOpUuXLoSHh/PSSy+xbt06GjRoAEBYWBgDBw5k48aNtt6eQgghhLh/RbbHhZubG+vWrbMbd6/ValGpVBgMBo4ePUpqaiodO3a07ffx8aFZs2Z3XWtZCCGEEIWLwWCwG66h0Wjw8vIiISEhV/FAeHg4gG1JRICAgABq1qxpKxMWFoafn58taQHQvHlzPD09Ja4QQgghHlKRnQVGq9VSp04dACwWC5GRkcybNw+VSsVjjz1GWFgYYJ10L6uKFSuyc+fO+3ovi8VCSkoKOp0uVzMhCyGEEM5IURSMRiMeHh6o1UXn3ka/fv1YsGABnTt3Jjg4mI0bN3L27FmGDx/OxYsXgbvHAxcuXKBUqVK25RCzlsk8/sKFC9lWVlKr1fj7+9vK5JbEFUIIIYoCR8YVRTZxkdXChQuZN28eAG+//TbVqlVj+/bt6PV69Hq9XVkPDw+Sk5Pv6/wpKSmcOXPGYfUVQgghClJgYCBeXl4FXQ2Hef755wkPD2fgwIG2bcOHD6djx44sWbLknvFASkoKHh4e2c7r4eHBtWvX7llG4gohhBDFmSPiimKRuOjUqRPNmjVj7969LFy4EKPRiKur6x3vYtzv3Y3MpZQCAwOzBT6OcO7cOQBq1Kjh8HMXJtIO0gaZpB2spB2kDTI5qh0MBgNnzpyxfa8VBYqiMGjQIM6fP8/EiROpXr06e/bsYcGCBXh7e6Moyj3jgTuVybpdUZQc7ybdafvd5HVcAfKzk6m4t0Nxv/6spC2sins7FPfrz8oRbeHIuKJYJC5q1aoFQLNmzUhJSWH58uWMHj0ag8GA0Wi0a8iUlJT7zgZlBi16vR4XFxfHVfymzIAnL85dmEg7SBtkknawknaQNsjk6HYoSsMTDh48yMGDB5k9ezbdu3cHrHNPmM1m/ve//zFixIh7xgOenp6kpKRkO3dqaqpdmejo6BzL3O9yqHkdV4D87GQq7u1Q3K8/K2kLq+LeDsX9+rNyZFs4Iq4oOgNYbxMdHc23336brXtm7dq1MRgM+Pj4oCgKERERdvsjIiKoWrVqflZVCCGEEHkkcyhHw4YN7bY3btyYtLQ0VCrVPeOBgIAAYmJiSE9Pv2uZK1eu2O3PnGNL4gohhBDi4RTZxEViYiIffPAB27Zts9v+119/4efnR6dOnXBxcWHHjh22fQkJCezbt4+WLVvmd3WFEEIIkQcCAgIAOHTokN32o0ePotVq6dKlyz3jgZYtW2I2m+0m77548SJnz561KxMdHc2xY8dsZfbu3UtycrLEFUIIIcRDKrJDRapXr07Xrl2ZPn06RqORSpUq8csvv/Ddd98xdepUPD09efHFF5kzZw5qtZqAgAAWL16Mp6cnTz/9dEFXXwghhBAOEBwcTLt27fjoo4+Ij4+nevXq7Nu3j2XLljFgwADKlSt3z3igcuXKdOvWjQkTJpCcnIy3tzezZs0iKCiITp06AdCiRQsaNGjAsGHDGDNmDCaTienTp9OuXTuCg4MLsgmEEEKIQq/IJi4Apk+fzvz581m6dClRUVHUqFGDOXPm0K1bNwBGjhyJWq1mxYoVpKamEhISwrRp04rUTOpCCCFEcTdnzhxmz57N4sWLSUhIoEqVKowbN47nnnsOyF08EBoaSmhoKDNmzMBisdCqVSvGjRuHRqMBrON3Fy1axJQpU5gwYQJ6vZ6OHTvywQcfFMg1CyGEEPdDUeDzKPguFkZWgDIFXaHbFOnEhZubG++++y7vvvtujvu1Wi2jR49m9OjR+VwzIYQQQuQXV1dXxo4dy9ixY3Pcn5t4wN3dnSlTpjBlypQ7lvHz82P27NkPW10hhBAiX6WYYch5+CrG+jrODEs0BVun2xXZOS6EEEIIIYQQQghxZ4kmaHPiVtICwO3oPwVXoTso0j0uhBBCCCGEEEIIkZ3BAk+eVjiUcnO50gwDrPwetKnQqEnBVu420uNCCCGEEEIIIYQoRi6lQ98TRnYk3ExapKZD6AoCr//H7Pe7FWzlciCJCyGEEEIIIYQQohhIMcNLZ6HaIYUfk3XWjUYTzP+GIS39OfTta9SuXrpgK5kDGSoihBBCCCGEEEIUcYoCg8/D1zEAN3taGE14ffMjq99qweMdaxVk9e7KaRMXRqMRnc6aAfrzzz+5cuUKHTt2pFy5cgVcMyGEEELkJ4kJhBBCiIc3+2pm0gLIMML2MOpGXGL7jD6UL+N112MLmtMNFYmKiuKZZ55h4cKFAHzxxRe89tprTJkyhV69evHPP843w2lxpShKQVdBCCFEESYxQfEjsYUQQuSN1ZFGRv1rubXhi+9ofv40u+c/5fRJC3DCxMWsWbO4dOkS9evXB2D58uU0b96cTZs2Ua1aNebOnVvANRQAO3bsYOLEiQVdDYfZuHEjQUFBxMbGFnRVhBBC3CQxQfEisYUQQjieokC/P6IZcEmHor755/+2PTzuZeSX5f0p4e1WsBXMJadLXOzevZtRo0bRvn17/v77b6Kjo+nfvz+1a9fmlVde4eDBgwVdRQGsXLmS69evF3Q1hBBCFGESExQvElsIIYRjJadkELz6LF/pbk22qT5wkrlBWjbNew5vT9cCrN39cbo5LhISEqhSpQoAe/bsQaPR0Lx5cwC8vb0xGAwFWT0hhBBC5BOJCYQQQogHc/JsFJ0+P861Xh1t2wIOHObnXpWoVa1UAdbswThdj4uyZcvy77//ArBz506Cg4Px9PQEYN++fTIRlxPo378/+/bt4/fffycoKIixY8fSt29fpk6dSpMmTXjuueeIiIggKCiIrVu32h37+OOPM3bsWNvr1NRUpkyZQqtWrahfvz79+/fn77//znVdUlNTCQkJYcmSJXbbz549S1BQEGFhYQAcO3aMwYMH06RJE4KDg+natSvffPPNXa/xtddes9v2xRdfEBQUZLfthx9+oHfv3tSrV49OnTqxevXqXNddCCHE3UlMUHxIbHGLxBZCiIe1bfc5mk74hWvd2tm2PRN/hX/falgokxbghImLDh06MHPmTAYNGsShQ4d47LHHAPjkk09YtmwZvXr1KuAaiokTJ1KnTh0aNWrE2rVrKV26NKdPn+b48ePMmzeP119/PVfnURSFoUOH8uOPPzJ8+HDmzJmDXq+nf//+XL58OVfncHd3p0OHDtmCmJ9++onSpUvTvHlz/vvvPwYMGIC7uztz5sxhwYIFVK1alYkTJz7UxG6bNm1i1KhRNG3alEWLFtGnTx9CQ0NZtmzZA59TCCHELRITFB8SW1hJbCGEeBiKorDgy330mLqTtFefAq0GgKdd0/imeyVUKlUB1/DBOd1QkXfffReDwcC+fft46aWXeP755wEIDw/nqaeeyvUXV2Gw9qcTfDjvN5JSMu5azmQyAaDV/ujwOnh5uDD5rfY82yM418fUqFEDT09P3N3dadiwIbt27cJkMvHBBx9Qr149ACIiIu55nt27dxMeHs7nn39Oq1atAHj00Ufp2bMnixYtIjQ0NFf16dWrF6+//jqXL1+mcuXKAGzdupXu3bujVqs5e/YsDRs2ZMaMGbbl9Bo0aEDz5s05cOAAtWrd/3rFFouFWbNm0bt3bz788EMAHnnkEVQqFQsXLuSFF17A3d39vs8rhBDiluIUEziKxBYSWwghiqfE5HRemryVzZdS4Z0Xwd06f0VbTwtfBrtRiHMWgBMmLnQ6HZMmTcq2fdOmTWi1Wm7cuIGfn1/+VywP/G/FX5y5eKNA63A1OpkZn++5r+DiTqpXr35f5ffu3YubmxtNmza1BVBg/ZLeuXNnrs/zyCOPUKJECbZu3cqQIUP4559/+Pfff5k+fToAbdu2pW3btmRkZPDPP/9w8eJFjh8/DvDA46MvXLhAVFQU7dq1s6t7mzZtmDt3LseOHaNFixYPdG4hhBBWxSkmcBSJLSS2EEIUP5v3XqbfCQOpffrYbW/mofB9XTU6pxtncf+cLnGxdOlShgwZkm27Vqvl559/ZvLkybaxhYXdu6+0vs+7Io7/7/LycOHdV1o99Hnc3d3v+y5AfHw8aWlpBAdnD2wy717khk6no2vXrrbg4ueff6ZSpUq25fPMZjPTpk1j7dq1GI1GKleuTJMmTYAHXy8+Pj4egFGjRjFq1Khs+6Ojox/ovEIIIW4pTjGBo0hsIbGFEKL4SE0z0O+Lo2yuUgtqe9ntq+8OP9dR4aUpoMo5mNMlLmbNmoWbmxv9+/e3bUtISOCjjz7ip59+olq1agVYO8d6tkdwru5GnDp1CoDatWvndZUcJnP8lMVisduemppqe+7l5YWfn1+2ya8eRK9evVi7di0RERFs3bqVnj172vYtWrSIdevWMX36dNq2bYu7uztpaWls2LDhrue8V90BPvzwQ1sQk1XFihUf5nKEEEJQvGICR5HYQmILIUTxsOzgNd4+ZSCtQVPbNm1aOk/6KXSv4MYzfuBWRJIW4ISTcw4bNoypU6eyfv16AH7//Xd69erFL7/8wpAhQ9i8eXPBVlAAoFbf/aOTOet7VFSUbdv169ftxqc2btyY2NhY3N3dqVevnu3x/fffs2XLlvuqT9OmTSlXrhzLli3j4sWL9O7d27bvyJEjBAcH0717d9udm127dgF3vivi6elpV3eAgwcP2p5Xq1aNEiVKcP36dbu6x8fHM2fOHJKTk++r/kIIIbKTmKB4kdhCYgshxL2lZxjp+cVxBqeVIa1aZdv2asnxnG+p45uGbrxUpmglLcAJe1wMGzYMsM4uvW3bNnbv3k1QUBCLFy+mbt26BVw7kcnb25tTp06xd+9e0tPTs+338fGhQYMGrFixgvLly6PRaJg/fz7e3t62Mu3bt6devXoMGTKEYcOGUb58eX755Re+/PJLPvroo/uqj0qlokePHqxcuZKgoCBq1Khh21evXj3+7//+jzVr1hAYGMjx48dZsGABKpUqx7qDdTzppEmTmDdvHk2bNmXbtm2cOHHCtl+r1fLWW28xbdo0AFq2bElERAQzZ84kICBA7ooIIYQDSExQvEhsIbGFEOLOzGYL3/7yNyN2RvLf453hZrJXn5jEuAoWxrUsgaaQT8B5N06XuIBbgcr8+fNp164dCxYsQKMpYimjQm7gwIGMGDGCV199laZNm+ZYJjQ0lEmTJjF69GhKly7NkCFD2LNnj22/RqNh+fLlzJgxg//9738kJydTpUoVQkND6du3733XqXfv3qxYsSLb8nhDhgwhOjqa+fPnk5GRQUBAABMmTOCHH37g8OHDOZ7r6aef5sKFC6xZs4YVK1bQqVMnPvjgA8aMGWMr8+KLL+Lq6soXX3zBihUrKFGiBN26dWPEiBGFeqkhIYRwJhITFB8SW0hsIYTITlEUNmz7m/FzdnKmQkUY+LgtadEo5ip/dC2Dp0vR/15UKQ86g5AD/fTTTzluX7lyJSdPnmTMmDGUKlXKtr1Hjx75VbVcycjI4MSJEwQHB+Pi4uLw8xfGcah5QdpB2iCTtIOVtIO0QSZHtUNef5/lRmGPCRwhP/4f5GfHqri3Q3G//qykLayKezs42/UfO32NoR/9yJ7DV6D7I/BUJ9u+3vpUNjd2R51HOU1HtIUjv8+cosfFyJEjUalUdmMCs76eOnWq3faiGKSI7CwWi90kVmazGcBuiTCVSiV33oQQogiRmEDkJYkthBCFgaIoLFh/iJFrj2OsUR2e7gNlby3//UoZhaXV8y5p4YycInGxatWqgq6CcEIffPABmzZtumuZZs2asXr16nyqkRBCiLwmMYHISxJbCCGc3ZWEdNp//x/nKzeEUY2z7f+wIkyqpKK4jR5zisRFs2bNCroKwgkNGzaMfv362V5fvHgRgICAANs2Dw+PfK6VEEKIvJQXMcHevXsZMGDAHffv3LmTChUqsHjxYtauXUtcXByNGjVi/PjxVK9e3VbOYDAwY8YMfvzxR1JTU3n00UcZN24cZcuWtZVJSEggNDSU3377DYvFQpcuXXj//fdtK2KIgiWxhRDCWRksMONYHB9e02HOYbnvR73hnfLwpF8OBxcDTpG4uF16ejpfffUVf/75J9evX2fu3Ln8+eefhISE0KhRo4KunsgnFStWtJtBW6u1flydZcyZEEKIvOeImKBu3bqsXbvWbltGRgZvv/02devWpXz58ixYsIClS5cyevRo/P39WbRoEQMHDuSnn37Cy8sLsK5usnPnTt577z3c3d2ZNWsWQ4YMYePGjbahBW+99RYRERFMmjSJ9PR0Pv30U2JiYliyZIljG0Y8EIkthBDORlFg5n8KU84bSdSWhMyFkjIMtCaFfrVL0q0EVHUtyFoWPKdLXMTHx9O/f3/OnTtHlSpVuHTpEgaDgV27djF37lxWrVpFgwYNCrqaQgghhMhjjooJPD09adiwod22Tz75BJVKxYwZM0hNTWX58uUMGzbM1jOjSZMmtG/fng0bNvDyyy9z+fJlNm/ezMyZM23zatSqVYtu3brx66+/0qVLF8LDw9m7dy/r1q2z1atcuXIMHDiQkydPyhKuQggh7JgUePkfE2vitKDV27Z7XopkcxM3Otb0LcDaORd1QVfgdrNmzSI6OpqNGzfyww8/2Cbjmj9/PtWrV2fBggUFXEMhhBBC5Ie8ignOnTvHl19+yfDhw/H19eXo0aOkpqbSsWNHWxkfHx+aNWvGrl27AAgPDwegXbt2tjIBAQHUrFnTViYsLAw/Pz+7ZErz5s3x9PS0lRFCCCEAYo3QZX+aNWmR6chpuh8M53qfMpK0uI3T9bj49ddfefvtt6ldu7Ztpmew3i0ZNGgQH3/8cQHWTgghhBD5Ja9igs8++4yAgACeeeYZ4NY8B5UqVbIrV7FiRXbu3AnAhQsXKFWqFO7u7tnKZB5/4cIFKleubLdfrVbj7+9vK3M/zp07h1qdN/eY0tLSgFvL3RVXxb0divv1ZyVtYVXc2yE/rl9RYLPBm08SSpGqc7NuNFtwWbOFT5q40aN9ZS5dPJdn759bjmiLrKs4PSynS1wkJSXZjT3Mytvbm5SUlHyukRBCCCEKQl7EBFeuXGHnzp1MnjzZlhRITk5Gr9ej1+vtynp4eJCcnAxASkpKjpM2enh4cO3atXuWyTyPEEKI4m1urBdL1P6gu7khw4D/5p/5v2cqEFDBq0Dr5sycLnEREBDAb7/9Rps2bbLtCwsLs5v1WQghhBBFV17EBOvXr8fb25vHH3/ctk1RFFR3WFcuc/udymTdrihKjj0k7rT9XmrUqIGLi8t9H5cbmXfQivuklMW9HYr79WclbWFV3NshL68/PjGNN9b9zde1gm5tPPwPL6b8x/992gNXF92dDy4AjmiLjIwMTpw44ZD6OF3i4oUXXuCjjz5Co9HQqVMnVCoVkZGR7N+/nzVr1vDee+8VdBWFEEIIkQ/yIibYsWMHnTp1sutd4eXlhcFgwGg0otPdChxTUlJsK4p4enrm2MMjNTXVrkx0dHSOZWQ5VCGEKJ4yDCbmf7mPyZtOkjj0ebiZyNbvCGNNM2+e7tahgGtYODhd4uK5557j0qVLrFy5ki+//BJFUXjnnXcAawCTde1tIe7H3e6oCSGEcD6Ojgn+++8/zp8/ny3hUaVKFRRFISIigqpVq9q2Z30dEBBATEwM6enpuLq62pVp3LixrcyhQ4fszm2xWIiMjKR37973VVdROEhsIYS4m3+vxNJryg5OBQbBmEG2pEWF2BvsfT2YimVkaEhuOd2qIgDvvfce27ZtY9KkSQwfPpwJEybw448/MmHChIKumiggY8eO5e2337a9DgoKYvny5bk6NjExkVGjRnHy5MmHrkeHDh2YPHnyQ5/nfuzdu5egoCCOHz+er+8rhBDOwJExwbFjxwCoX7++3faQkBBcXFzYsWOHbVtCQgL79u2jZcuWALRs2RKz2WybrBOsk3qePXvWrkx0dLTtfcD6Ozw5OdlWRjgPiS2COHeu4CcAFKKo+vT3SwT+msipgc9Aqwa2pEVFjZlDXfwkaXGfnK7HRaZKlSrx1FNPERsbS8mSJdFqnbaqogCsXbuWChUq5KrsqVOn+OGHHxg4cGDeVkoIIUSecFRMcPbsWUqWLEnJkiXttnt4ePDiiy8yZ84c1Go1AQEBLF68GE9PT55++mkAKleuTLdu3ZgwYQLJycl4e3sza9YsgoKC6NSpEwAtWrSgQYMGDBs2jDFjxmAymZg+fTrt2rUjODj44RpB5DmJLYQQjmAwK3T/MYKdvpUg8FY/AU8svFtJzTvlNfjIn7b3zSmb7Ny5c8yYMYOwsDCMRiPr169n1apV1K5dO9dfEGazmVWrVrFu3TquXr1KhQoVbN1KVSoVx48f56mnnsp23CuvvCLzaBQCDRs2LOgqCCGEyAeOiAky3bhxA29v7xz3jRw5ErVazYoVK0hNTSUkJIRp06bZ5q8ACA0NJTQ0lBkzZmCxWGjVqhXjxo1Do9EA1ok8Fy1axJQpU5gwYQJ6vZ6OHTvywQcfPPD1i/wjsYUQ4mH9l2Ii5LcEokrdWl7bPTmZsdVdeKuKjhJO+dd34eB0Q0XOnDnDM888w99//83jjz+OoigAaLVapk+fzpYtW3J1noULFzJr1iwee+wxFi1aRPfu3Zk6dSrLli0D4PTp07i7u7N27Vq7R//+/fPs2oqSoKAgvvnmG4YOHUqDBg3o0KEDa9asse2PiIggKCiIlStX0qFDB1q3bm0b9/vXX3/x9NNPU79+fdq0acOcOXMwm822Y00mEzNmzKB169Y0atSI0NBQu/2Z75+1O+c///zDq6++SqNGjWjVqhXvv/8+8fHx7N27lwEDBgDw1FNPMXbsWNsxq1atokuXLgQHB9OzZ09++uknu/eIjo7m7bffpnHjxjz66KNs3rz5vtupY8eOfPjhh3bbEhISCA4OZsOGDQD8+++/vP3227Ro0YLg4GA6dOjAggULbJ/9282ZM4devXrZbduxYwdBQUFERETYtt2rnYUQwtk5KibINGnSJH755Zcc92m1WkaPHs1ff/3F4cOHWbFiBdWrV7cr4+7uzpQpU9i3bx8HDhxg7ty5lC1b1q6Mn58fs2fP5vDhw+zdu5epU6fKxJy5JLFF7uRFbDF27FiJLYR4SEei0qjxezJRvn7WDWYLj0b8S1xHdyZUl6TFw3K65ps5cyYBAQF8+eWX6HQ61q1bB8Ann3xCcnIyq1ev5rHHHrvrOSwWC59//jmDBg1i6NChgHXcaWxsLCtWrGDw4MGcPn2amjVrFmh2fW0MfHgZku7x+95kqgGAdr/j6+ClgcmV4dlS93/sjBkzaNu2LfPmzeOvv/5iypQp6PV6nnnmGVuZOXPm8PHHH2MwGAgODiYsLIzBgwfTtWtX3nrrLS5cuMBnn31GfHw8EydOBGDq1Kl8++23jBgxgoCAAD7//HMOHjxI+fLlc6xHZGQkL7zwAoGBgXz66acYDAamTZvGqFGjmDNnDh9++CGTJ08mNDSUJk2aADB//nwWLVrE4MGDadKkCX/88QcjR45EpVLRvXt3zGYzgwYNIjk5mSlTpqAoCjNnzuT69ev31UY9e/Zk3bp1TJw40XZHbvv27QB06dKFlJQUBgwYQLVq1Zg+fTparZYffviBuXPnUrt2bTp0eLBZhnPTzkKIwu2Ho1f58Egi1d1hYm0FjaboTRDoiJiguJHYQmILiS2EyF+KAp+dSmRMhBZzyRLWjYkpjDdFMuWZwAKtW1HidImL/fv3M2XKFNzc3LJlcPv27cvIkSPveY6kpCT69OlDly5d7LZXrVqV2NhYUlNTOX36NEFBQXc4Q/74XyScSc9NyZtLsxkdX4erRpgR+WDBRbVq1Zg5cyYAbdq04erVqyxevNguuOjTpw89evSwvZ49ezYNGjTgs88+sx3n4+PD+++/z6BBg/D09OSbb75h+PDhti7ALVu2pH379nesx8qVK9FoNCxbtsx2V8vFxYVPP/0Uo9FIjRrW4KxmzZpUrlyZxMREli5dyquvvsrw4cMBeOSRR0hJSWHmzJl0796d33//ndOnT7N27VpbcisgIIC+ffveVxv17t2bJUuW2E3w9vPPP9OmTRu8vb05ceIElStXZvbs2fj6+tqud8eOHezfv/+Bg4t7tXPFihUf6LxCiIIXHZtK129Oc7hWHahZnsNA96ijtCyvv+exhY0jYoLiRmILiS0kthAi/1xMh2cPpbIPb7jZuU4dE8ea8qk831SSFo7kdIkLRVFwcXHJcZ/RaLxjF7esfHx8snWhA/jtt98oV64c7u7unDlzBr1ez+OPP8758+cpX748b7zxBk888cQD1/3cuXOo1bkfffMCXtxQlyZFufsxmdecF8tteagsPE80p04l3fexjRs35tSpU7bXtWvXZtu2bezatcsWYHp4eNjKZGRkcOzYMfr168eJEydsx5UrVw6LxcLmzZspUaIEZrOZSpUq2Z27QYMGnDlzhrS0NNv2qKgoTp06xZ49e6hVqxZXrlyxla9QoQKzZ8/m2rVrXLp0CbDO/q7Vajl06BAZGRkEBATY1aN69ep8++23/P7772zfvh1PT09cXFxs76dWqylTpgxxcXF2dbuXKlWq8PXXX1OiRAmSkpIIDw9n+PDhnDp1Co1Gw4QJE4iMjOTAgQNERkZy4cIFDAYD165d49SpU3b19/f3x2w2k5GRYVeHzGs/d+4cMTEx92znjh075rr+zigtLQ3gvv4fiiJph+LXBhaLQsdfM7jeJMS2TRcXTyVfE2lp5oduB4vF8rBVdChHxATFzbv+ue1xYc1YaLU6h9fBS2Otx4PImpAA67CIbdu2ce3aNdu2rEN40tLSOHbsGCNGjMBkMtm2t2nTBovFwt69eylVqhRms5k2bdrY9ru4uNC2bVsOHDiQYz0OHz5M06ZN7Yb5dOzY8Y7fn0eOHCEjI4N27dplq8e3337LlStXOHToED4+Pna9fevWrYu///01Vs2aNQkMDOTnn3+mZcuWtuErn376KQDBwcF89dVXGI1Gzp07x8WLF/n7778xmUwYDIb7eq9MuWlnSVyI4sSkwOxICx9cVDCq3W3bPc5dZMejPrSo+oC/BMUdOV3iol69enz55Zc5fjFs2bLlgWflXr9+PXv27GH8+PFcv36duLg4Ll26xMiRI/Hx8eGHH35g7NixqFQq+vTp85BXkTvd9Ul01987YZAZmLu5ueV1le5LZhY/k4+PDwDJycm2upYoUcK2Pzk5GYvFwurVq1m9enW288XGxtpmir998rTbZ4DPKjk5mYCAgFzXOynJ2uZZx6RmFRcXZ5sx/nZ3q8edtGnThi1btjBkyBDCw8PRarU0bdrUtn/9+vVs2rSJ1NRUSpcuTa1atWxdPx9EbtpZCFE4TfsjmuuNbv3xFXz9MvOqpeBtLnrDRCDvYoKi7NlSuevpcOqUdRnM2rVr53GN7k+ZMmXsXmfGGvHx8bYkgp+fn21/YmIiFouFmTNn2npqZBUdHY1eb+2NdPt3eKlSd26ohIQEatWqlet6x8fHA/Dcc8/luD86OprExMQc44jSpUvn+n0y9e7dm88//5yJEyeyfft2dDqdXQ+SxYsXs2zZMpKSkvD39yckJAStVvvAyb7ctLMQRdnqKPjff1DLDXqWhGn/GvjHor81Y2RCMvUOHuSPt5pR0se5/mYrKpwucfHGG28waNAg+vbtS4cOHVCpVGzbto0FCxbw+++/53p97ay2bNnCxIkT6dq1Ky+++CLp6eksW7aMoKAg2xdkq1atiIqKYv78+Q+cuKhRo8Yd7ww9jMw7aM4WXLi7u9vV6fTp04C1J0ZmRt/f399WJjk5GYChQ4fmGISWKVOGM2fOANZAJeu5NRoNarUaNzc32/YyZcpQu3ZtfH19URTFrrzBYCAsLIyQkBASExMBa3fM2rVr2+7aLFiwINukamAdUvTvv/8SHh6erc0zMjIoWbLkff1fvPzyy6xZs4aUlBSOHj1K586dbXdbNm/ezFdffcXEiRPp1auXbfb6li1b2t4na/21Wi1arRadTmdXh8x2q1Gjhi1ZdLd2zum6CxNn/ZnIb9IOxasNjpyJ4svSfqC2JikGKLGsfKIy4Lh2yMjIsOupVdDyIiYQzi0uLs7u9Y0bNwBrXJBTbwEPDw8gd7FFbGys3fdfZrIhJ56entkS/Vlji9tlfn/fLbYoUaKE7Xqyuls97qRnz57MmjWLAwcOsHXrVjp27Gi7abR582Zmz56dY2xxJyqVKluPq5SUFNvz3LSzEEWNosANk7UX26KbU9EcT4X1NwCyDM/84yBvuyYyc2wbtNoHv/ko7s7pVhVp0aIFc+fOJSEhwTb78dKlSzl58iQzZ8686y/dnHzxxReMGTOGdu3aMWPGDFQqFW5ubjz66KPZfsk++uijXLlyxe4Xtbiz33//3e71r7/+SrVq1e745eXp6Wkb0lGvXj3bQ6fTMWvWLK5du0ZISAh6vd5u1neTycRff/11x3o0atSI/fv32/2/hYWFMWTIEG7cuJGt90KDBg3Q6XTcuHHDrh5nz55lwYIFADRv3pykpCTCwsJsx124cIHLly/nun0y+fv707BhQ77//nvCw8Pp3bu3bd/hw4cpV64czz//vC2wOHnyJLGxsXe8K+Lu7s6NGzfsAoyDBw/anuemnYUQhcvf/8bQ5vtIFH/r71ff5ET+r6XvPY4q/BwdEwjnJ7FF7jg6tvDw8JDYQhRryWbYEQ+LUnwZcr0U1f5IxX2XkdL7byUtsrkag+/ib9jWxoc5I9pL0iKPOV2PC7g1hvDixYvExsbi4+NDtWrV7nuOh1mzZrFkyRL69OnDJ598YhuGcOHCBcLDw3nyySdt3QfBeqfJ1dUVd3f3O51SZLFr1y4mT55Mhw4dbPNCzJ49+67HvP3227z55pt4enrSuXNn4uLimD17Nmq1msDAQNzc3Bg0aBD/93//h4uLC3Xq1OHrr78mJibmjr0EXnrpJTZt2sRrr73GK6+8QmpqKjNmzKBLly5UrVrVdofmjz/+wN3dnerVq9O/f3+mTZtGQkIC9evX559//uGzzz6jY8eOeHp60rp1a5o2bcq7777L6NGjcXd3Z/bs2eh0DzYWuHfv3nzyySd4eXnRqlUr2/Z69erxzTffMH/+fJo1a8b58+dZsGABKpWK9PScZ1dr1KgRP/zwAx999BE9evQgPDycHTt23Fc7CyEKj+8PX6XvCROmljfv8ioKG0Lc0DvdrYe84aiYQBQOElvkniNjizZt2rB69WqJLUSxoyiwMhreOmcmGQ1Q1q4zhY3JDN9shYRkaBhEiZQkJtRw4bXFffFwL3qTYzsjp0tcPPfcc3Tp0oXOnTsTEBBwX3MXZLVy5UqWLFnCgAED+OCDD+wCnOvXrzNp0iRKlSpF586dAesEYL/88gtNmjSRYCiXXn31VU6dOsUbb7xB5cqV+eyzz+jWrdtdj+nYsSMLFy5kwYIFbNy4EU9PT1q1asXo0aNtXRzfeecdXF1d+eqrr0hMTKRLly4888wz/PHHHzmes1KlSqxZs4ZPP/2UESNG4OXlRbdu3RgxYgRgncTq8ccfZ8mSJZw4cYLFixfz7rvv4uvry7p165g7dy5lypThpZdeYtiwYYC1y+SiRYuYOnWqLen1yiuv2JYbu1/du3dn6tSpdO3a1S5A6du3LxcuXOCbb75h2bJl+Pv7M2jQIM6fP293pyOrRo0aMWLECNasWcPmzZtp2bIl06ZNY/DgwffVzkII56YoCoM3/MNynypQ3T1zI+P80mlfunj8HDsqJhCFh8QWuefI2KJNmzYSW4hi5z8DvHA8gz8yXIAcekvEJUJULFy7QckjJ+lXrxQd+9anTvXS1Kjie1+LMoiHp1KcbEruV199lX379tmWmurSpQudOnW6r3G7UVFRdOzYkYCAAKZMmZJtf506dRg4cCAXL15k5MiRlC5dmrVr17Jr1y6++uor6tWrd191zhwTHBwcXGzmuAgKCmLMmDEMGjQo397TGdshv0kbWEk7WEk7FM02OHwthU8P3mDbDTNxNaratutSUlhXR0Mff9dsxzh6jou8+j67X46ICQqj/Ph/cMafHYkt8l9xv/6spC2sikM7mBVYec3Cm2fNpGddWenwP2hPnKWhq4EetcoSUt0PXx83fLxcqVujdLEbCuKIz4Ijv8+crsfFsmXLSEtLY/fu3ezcuZNvvvmGBQsWUKFCBTp37kynTp3sVmTIye7duzEYDJw5c4Znn3022/6wsDAWLlzIrFmzmDt3LvHx8dSpU4fPP//8vpMWoniyWCz3XDZQpVI91OogQojCSVFg7CU4nQ4LqoL/Xb6nzQpsjweSklk9bxs/x0Fcv8egZGXIsvhAlRtR/Nm+JJU9Hb90pTNzREwgRGEhsYUQeUdRIDzexKx/UthmcCVJ5wLamz0mklIo8d2vfNrOn5DBVfBw0xXpxE1h5XSJC7Au+9m5c2c6d+6MoigcOnSI2bNns3LlSlatWnXPder79u1L37597/k+kydPdlSVRTGzYMEC5s+ff9cy/v7+7Ny5M59qJIRwFr/Ew6f/WZ+bFPjhDrHPF/8k8kmcK+cUPeAJtRtDjUqQ5Y6OKsPAQE08y3qVyVxMpNh52JhAiMJCYgshHM9ogXGH4lh8Q0uSlxfgA1nvARw4yVBzFNP/1xUvDxf5TnFiTpm4AOvyjmFhYYSHh7N//36Sk5Px9fWVGcSdRObSp8XVM888Q7t27e5aJuvEr0KI4uO7LCso/hgHe5OgudetbTcS0mj+XSTna9SwP7BWgO1p1Zgo3vdXGNC8DC4aWWZQYoLiQWILiS2EcKQt1wwMPGEgzr0kZPkexmyBk+epePoM6wbUp2VI3QKro8g9p0tcjBo1ivDwcGJjY9Hr9TRu3JjXX3+d1q1bS5cd4TTKli17x5nIhRDFl6LA93H22yZdURjllsjmiyn8dy2BrWl60mplSVpcuQ6eblDSG4DnS8HKFmXQyZxfEhOIYkViCyEcQ1Hg9T0xLFX8IMuKH5oLETSIj+KFshq6dihHnSHdZYLNQsTpEhc//vgjAPXr1+fVV1/lkUcekeVJhRBCFApHUiDCYL9ta7yKrfE+4OIDVSrc2mG28MjZv2lw9TJNGlTCVK0uWrWa/qVBU0yHhdxOYgIhhBD3Y39UOs/9EcO//hXh5nep6kIkr1qimfdsMC76igVbQfHAnC5xsWHDBv766y92797NyJEjAWjQoAGtWrWidevW1K9fXzJjQgghnFLW3hb6q1EYyuc8zENtMLK0QjqDHg0GgvOncoWQxARCCCFy46oBng5P5C+1F/jfSk5UOHCEX3r4U7dGw4KrnHAIp0tcBAcHExwczGuvvUZKSgp79+5lz549bN26lfnz5+Pl5cW+ffsKuppCCCFENt9nmd/CMH8dvNIHqlfEIz6ekMQYAvzcqVDGiyEhnlR387rjeYSVxARCCCHuZdG/6bxzWYVR731rY4aBfglXWPlmfTQaSXAXBU6XuMhKq9Wi1WpRq9WYTCYURZE7K0IIIZzS3ykKB1Ju9kuNjIJrMTTY8hPzQ5+kdUs/VKoSBVq/wk5iAiGEEFkpisIL26/yjWcFyJzKIjmVav+cZkOfqoRUrl6g9ROO5XSJi/Pnz7Nr1y527drFgQMHMBgM+Pv707FjRz766COaNGlS0FUUQgghsCjwVxKcSbGw/XIy6zPcQXvza/XoGZ7rEcwXoX1w0TvdV22hITGBEEKIrMxmC0f+ucb+45EsPJ/G8fZtbPt0x07zaTkD77zVEJVKJosqapwumurZsycAderUYciQIXTq1ImgoKACrpUQQghh9d+NFMb/+R+b3MoS7+0NqAHvW9+o8Um87JPBssl9pUfAQ5KYQAghBEDY4SvM/mofP6boSKkbCH6V4NHStv2BJ//mtycqUaGsDMMsqpwucTF+/Hg6depEuXLlCroqQgghiglFUTh5NorrN1KIQUMUWhLRkISaJNQkKhqSUfN3ookzek8oWzP7ScwWvPYdZUYtPYNHd5C7PQ4gMYEQQhRv16KTeG/mDlbFqODJruDjma1MG0M8vw2qjVot37tFmdMlLl588cWCroIQQogiLtUMW+MhSJ3BlvX7+L8/LnCheWMIDABvjzsf6H3b64v/4Xv6HNU8tfSs7M7YYcG4uujysObFi8QEQghRPCmKwvINhxg1aweJvTrAY03t9qsUhRIqM8+XVvFZ9RJIB8eiz+kSF0IIIUReumqALn/DiVTArIUkHxj0HLjq73ksAMmpBCTG8XoVPa/39sXnhTb3PkYUuLCwMGbNmsXp06fx8/PjiSee4M0330Sj0aAoCosXL2bt2rXExcXRqFEjxo8fT/XqtyZ2MxgMzJgxgx9//JHU1FQeffRRxo0bR9myZW1lEhISCA0N5bfffsNisdClSxfef/99PD2z3yEUQgiRs7MXbzBk4vf8/k80DH0OAqvY9nXzsTDSX017HxValfwpW5zI/7YQQohi49tjUQyK9iDB7WavCo0GWta37debTJRNScQ3NQU3kwFXkxFXowk3kxFXk5ESKguvtatKgyD/AroC8SAOHjzI4MGD6dWrFyNHjuTkyZPMmTMHtVrNsGHDWLBgAUuXLmX06NH4+/uzaNEiBg4cyE8//YSXl3W89MSJE9m5cyfvvfce7u7uzJo1iyFDhrBx40Y0Gg0Ab731FhEREUyaNIn09HQ+/fRTYmJiWLJkSUFevhBCODWzAt/FwskUC3sPXGLb7/9gci8FE/qCr7Wrow6FedVUvFZOulYUV5K4EEIIUWRFXEvgzwOXOK7xYGWaB1fLlAW3m2NgE1PAzQV01q/CF0vDgqpavLW+gG/BVVo43MyZM2ndujXTpk0DoGXLlsTHx7N3714GDhzI8uXLGTZsGAMGDACgSZMmtG/fng0bNvDyyy9z+fJlNm/ezMyZM+nRowcAtWrVolu3bvz666906dKF8PBw9u7dy7p162jQoAEA5cqVY+DAgZw8eZK6desWzMULIYQTS7dAvzOwMRZADeWqwnNV7cqU1cGGIBWP3D5cUxQrkrISQghRJK37+QTVnltJv381TPOpztVy5SBz4q7rNygxdxWvHw1jYgUz39eC1TXBW9L5RU5sbCyHDh3imWeesds+evRoVq9ezdGjR0lNTaVjx462fT4+PjRr1oxdu3YBEB4eDkC7du1sZQICAqhZs6atTFhYGH5+frakBUDz5s3x9PS0lRFCCHHLtZtDN61Ji5w19YQD9ZGkhXCeHhcJCQls3LiRa9euUbt2bXr16oVWa1+9K1eusHz5ciZNmlQwlRRCCOF0Uo0WPvwjgnNJJkwqNSZUxKQY2JXkAR+/dStZAajiE+lsjGdmMx/q9nldVv5wUo6MCU6fPo2iKLi7u/P666/z119/4enpyQsvvMCbb77JxYsXAahUqZLdcRUrVmTnzp0AXLhwgVKlSuHu7p6tTObxFy5coHLlynb71Wo1/v7+tjJCCFGcGS1wLBUSzHAgycKUK5Cs3LyPnmGEDdvxVlt49flmVKtahjI6eMwXXORWu8BJEhfR0dE8/fTTXLt2zbZt+fLlLFq0iIoVK9q2RUVFsXbtWklcCCGEAOBEipqBV/xILVvGfnRHSfty7mYjTyb+x8zWZShdwv6PS+FcHB0TxMXFATBmzBh69erFwIED2b9/P4sWLcLFxQVFUdDr9ej19pOzenh4kJycDEBKSgoeHtlXm/Hw8LDV825lMs9zv86dO4c6j6bKT0tLA+DUqVN5cv7Cori3Q3G//qykLazyoh0um3UsS/dju8GLBNufn1l+tyWlwryvaO1lIvTt5pQqcQPibwDwb7TDqpEr8jm4xRFtYbFYHFUd50hczJ49G7PZzJdffklQUBBbt27lf//7H/3792fNmjX4+8skaEIIUdgpCrxwFjbegGXVoX+Z+zv2mxPRrD+fRJJKS6JWT4zejQsu1VHK3vmrzDs9jaHVXBntr6OUrsodywnn4eiYwGg0AvDII4/w3nvvAdCiRQvi4uJYtGgRQ4YMuWPPm8ztiqLkWCbrdkVRckwy3Gm7EEIUBzEWDc8lBRCv3OG7es9R1N9uZ3ivarzSpxZqtfSEFDlzisRFWFgYb775Jo0bNwbgqaeeon79+vTv358hQ4bwzTff2Gb1FkIIUTj9lQTfxFifv3UBevtCiZvfQoqisP94JDHxaSSiJgodUSotUei4pmj5I1VDondpKFM6x3Oro2N5QonHS6tCqyhoFYWm/p4MbFFGgqBCxtExQWYviEcffdRue6tWrfjyyy/x9vbGYDBgNBrR6XS2/SkpKbb38fT0JCUlJdu5U1NT7cpER2e/NZiamvrAy6HWqFEDFxeXBzr2XjLvoNWuXTtPzl9YFPd2KO7Xn5W0hZWj2+HJk2biFevKSxiMcOIcRMfhYjHTTJVGN39XHl81gLo17+NuRh6Sz8EtjmiLjIwMTpw44ZD6OEXiIi4uLtvY0sDAQBYsWMDAgQN55513WLZsWQHVTgghhCMsu37reYIZ5lyFiZXg572XeP3XCC5XrQblqoCLPvvBd5qUKyUN14Mn+e3xSrSoXS1P6i3yl6Njgsx5JzJ7XmQymUwAaLVaFEUhIiKCqlVvzWSf9XVAQAAxMTGkp6fj6upqVyYzwRIQEMChQ4fs3sNisRAZGUnv3r1zXV8hhCgqPtlzlY2Ut75ITYcJC2hayYvJb7WnQ/Oq6PVO8aeoKCScou9ixYoVOXjwYLbtTZo0Yfz48ezZs4ePPvqoAGomhBDCERJNsP6G/baZERZqLjlJj6SyXG7XGqqUzzlpcZPm0n/0uPovo5Iv8lHieRbH/82ciN3s6qKnRe2yeXwFIr84OiaoUaMGZcuWZevWrXbb//jjD8qUKUPPnj1xcXFhx44dtn0JCQns27ePli1bAtblU81ms22yToCLFy9y9uxZuzLR0dEcO3bMVmbv3r0kJyfbygghRHFwMSGDZiv/YXyyj22bbtOvzHqtFWFfv0q3R2tK0kLcN6f4xDz22GPMmzcPFxcXOnfuTLVqt+6aPffcc5w/f57Vq1fbBQNCCCEKj29iIPXm/ExaFEyoSFLUJNWra1fOJyONEhnp+GSk4W1IxycjHR9DOoGu8HbP2pT0cbMrf+qUDAMpahwdE6jVakaOHMl7773HxIkT6datG3v27GHTpk1MmjQJT09PXnzxRebMmYNarSYgIIDFixfj6enJ008/DVh7bXTr1o0JEyaQnJyMt7c3s2bNIigoiE6dOgHWeTMaNGjAsGHDGDNmDCaTienTp9OuXTuCg4Md31BCCOFkjBYYczieOQluKDVr2bZ7R15l/7stCAzwK8DaicLOKRIXL730EufPn+ezzz4jMjKSyZMn2+0fN24cAKtXr5al64QQwkllGExs+fMsJ5MhUudKslqLQaXGoFKz360kaK1d7FUrt0D/3pA5YaHZQov0WOY0K0kzHzfAjWzLgohiIy9igj59+qDValmyZAkbN26kfPnyfPTRRzz77LMAjBw5ErVazYoVK0hNTSUkJIRp06bZzaURGhpKaGgoM2bMwGKx0KpVK8aNG4dGYx27rVKpWLRoEVOmTGHChAno9Xo6duzIBx984IhmEUIIp/WfAb6OVvjf2XSu60tA5og6i0JwahzbepelgqtTdPQXhZhTJC70ej3Tpk3jjTfeIDU1Nccy48aNo0OHDvz888/5XDshhBA5iUtI4/yVWJJNsOq6hW/+M5JWtQaU0d35oMgojH8eBr0Lqm6tqKeksbJVSRr6lsq/igunllcxQa9evejVq1eO+7RaLaNHj2b06NF3PN7d3Z0pU6YwZcqUO5bx8/Nj9uzZua6TEEIUZiYFpkbAlCvWnpTob/WK9D15mi/blaZbTd+7nEGI3HOKxEWmzAm07qRly5YyTlQIIQrQjbhUQv9vF+u3/s3lqwlQvRIMegLK+kJQLk7w0270Og2DSpmY2FxN2VIyN4XImcQEQgjhnNLM8NN1AxPOGTml9QCy9H67+B99b1ziq9ea4iLzWAgHkk+TEEIUI/9FJfL3uVtLNqaj4jpaLKhQo6ACLBaFc1cTORWRSIxFTYqHOwa9HpNaw6X/4jHE6aBpQ6hWCepWuzXkA9ClplFXSaOiIZWSJgN6xYxOUdApFirqLHQc3YK6NXrj6nKXXhlCCCGEcDpHUmD8yRS2prtg1upBe3NCbYsCO/fhvv8YX7zZiqdfkKSycDxJXAghRBGWnJLBX6eusybSyJ//pXI50QjubuDhBiW9oLQvqG+bJ0AN+N983C4w5/cpk5jASLdERnWoiFbtBkjXUCGEEKKwOpYC4UngroHLGbDxhsLBFBXgYf8XZFwi/N9GWriaWDWvLzVlAk6RRyRxIYQQRVBsYjpvfnuK9Yk6zA2CoLQOSjv+ffy08E55GOvvg07tc+8DhBBCCOG0FAWWpPsx9+jte7Lc5EjLwOXkWR7RZfBydXfaLemLf1nv/KymKIYkcSGEEEXA+fgMJm0+xffnE0gtXxZjtYoQFHLXYzQWC75pKfimpaC1WFAARaVCQYW3ixp/H1cqemioqLVQSq3golLw8HDB7OZKhgVCPCDILXuHDSGEEEIUPqlmmJhajg2GO6zsFRkFfx7knWoufPpmG/Qyh4XIR/JpE0KIQig+MY0DJ6PYFWXh59O+RJQpC4ENcxzKoTMaaZIaS9/SatoG+lFKr8ZPC14aNSqVF+CV/SAhhBBCFBvfx8LbF+Bi1qTFjnCIiQezBU6ep6w5nVXTnqBL6xoFVk9RfDll4uLnn39m+/btpKSkYLFY7PapVCqWLl1aQDUToug7mQoHk+EpP+u4RpG/0tKN/H3xBvFGC/+lKSw5l8I+lxIY3d0BBWu3iJv/ujaE+l52k2NmUhmNlL8Rw7u1PHgtyBs3jazeIQoniQmEECLvJJvhzX9hVXSWjSYzrNwCe26NF+n6SHVWhj5B2VKe+V9JIXDCxMXSpUuZNWsWer0ePz8/VCr7Psi3vxZCOE6yGdqcgFgTHE6Bz6oWdI2KnjijwuEEM9eNEJFk4OK1JE7fSOcErsR4eWPW60Fb7tYBAbk9cSJVo6/Rv3F5elf1ooG7Dp26fF5cghD5RmICIYTIGyYFtsTC2EtwNj3LjjOX4MufIOI6gQF+PNYhiK6tq9OhRVXUOdwoESK/OF3iYu3atXTu3JkZM2bg4uJS0NURolg5lGxNWgB8FQMzAwr3/AUWBbbFw8UMMFigjTeEFNCNgugMCy/viuEnXUkUXeZSoFrQukMuOkNok1NuPlNZ58dSqVCrVbhhpq+7gSmtXfEvcYclP4QopCQmEEIIx/kpDhZfs8Z6Z1MtRJmzJCIyDPD1Vth1iAql3fn007481yMYjUaSFcI5OF3iIioqiilTpkiAIkQBOJZ663mUEQ4kQ7NCOv2B0QJ9/oGf4u23f1IZ3veHB7lRm5ZuJDnVAFhHayRYINFsPVFUipGdl5M4EW/CDJjNFiJTzFy1qEnzLYHRtyS4l7n7GySn4pKahqcGXBULOrOJWnozExuVpEV5j2zFT506BUDt2rXv/2KEKAQkJhBCCMdYFwPPnbGONLXKkpC4fA2WbIBrMXRuUZEpbzaleZP6BVBLIe7M6RIXVapUISoqqqCrIUSxlDVxAfBDXOFLXFgsFs5fjuONCC07cliec9xlmLn/OvqMDBSVClRqFJUKi0oFKhWK2rqqhgoFFAXVzTklEjU6DD5eoHUFowk0atDr7E/u4nPv3hMmMz7/nMMnJRl3swl/Pw+ql/OkW0V3ujUqiZuru8PaQojCTmICIYR4eDvi4cWzWZMWWOex+Ptf+H0/vpcjaN2wIk+98whNAvUyDE84JadLXLz66qssWrSIJk2aULFixQc+j9lsZtWqVaxbt46rV69SoUIFXnjhBfr164dKpUJRFBYvXszatWuJi4ujUaNGjB8/nurVqzvwaoQoXI6l2L/+IQ4mVy6YutxLYoqBBRuP8NO/iRxPVRHt6Y3JvywmvxKg9b6VVDCZYeOvUMILurQEILbsQ05Uqb3PWUvNFtTRsZSKjmZ6HVdeGhwoQYEQueComEAIIYqrX+Ohzz8KRuVm3BF2DFZ9j4tK4Y3nmvDcB21oWs/fFpdk9uYUwtk4XeJi+/btxMfH07lzZ8qVK4ebm5vdfpVKxY8//njP8yxcuJClS5fyxhtv0LBhQw4cOMDUqVNJsFIvUwAAZ6pJREFUS0tj8ODBLFiwgKVLlzJ69Gj8/f1ZtGgRAwcO5KeffsLLq5DdYhbCASwKHL+tx8XhFIjMAP987qWdlmHi6LloTl6OI8miIlVlTRSYLQr7khT2mlyI9ikH5UpCuXucbMVm2Hvc+vxCJPTvBe6u918piwVdYjIuihmLRguKgktaGvqMDFAUNCgEaMw08NHioVOjADVKudEqwIdALx2u6lJAqft/XyGKMUfFBEIIURxtiYWn/lEwcjNpcfwsfL6Z5nXLs3LaEwRVlbhEFB5Ol7hITEwkMPDhJpizWCx8/vnnDBo0iKFDhwLQsmVLYmNjWbFiBc8//zzLly9n2LBhDBgwAIAmTZrQvn17NmzYwMsvv/zQ1yFEYfNvOqRasm//MQ6G3Cs5cB8UBXZeTGDR/mucjE7janw6Sa5uKJXKofj5gFYLOi1QHnxyWBXD9+7n18Qn4oaCh1ZF8xv/0aipHzRtB0D50p4ElYpB4+eDVgUalXWEp4bM54ptm4I1mWMGFFRU9XXD09X7tne7/bUQwpEcERMIIURxY7TA5Aj45IpiHRYLcOws2v9bz0dvtWPMoNZo77f3qBAFzOkSF6tXr37ocyQlJdGnTx+6dOlit71q1arExsYSHh5OamoqHTt2tO3z8fGhWbNm7Nq1SxIXoljKOr9FG2/4M9H6/LvYeycuDBa4YQJfLcTGp7DjnxsciU4nQaXhhqLh7wwVV7VuZLi5YnJzw6L3gYo+8DA9v40mSqUm06SEhnblXWlWUkeIB5TQZk0meAO1HuJNhBAFyRExgRBCFBf/plt7WayMUjiSqro1E/n+kwRu/511X75Cg1oOvBslRD5yusSFI/j4+PDhhx9m2/7bb79Rrlw5rl+/DkClSpXs9lesWJGdO3c+8PueO3cuT9Y3TktLA2TMmbRD3rbBr2mlgNIA9DBFclJVlhuKlp/jFX4+cZ4AjdGuvNFkYe62y/xRohIXawRi0uutOyzuoPbIPFXuWRS0CYmoDEbUZjNuGvDUqnBTTLiYrJ0cLSoV5VUG2uqT6FDKQskyNyeyTLM+rmJ9FBfyMyFtkMlR7WCx5NDtSgghhFMzKzDxCkyNyJyA82bCwmKBH/7kyYxoPl/7Kl4eskKTKLycInHRoEEDVq5cScOGDalfv/5dJ61TqVQcOXLkvt9j/fr17Nmzh/Hjx5OcnIxer0ef+YfWTR4eHiQnJ9/3uYUoCs6ab32Z1dam84JLHPPSS6Og4ot0PyZ5XLPtv2TW8eZxFf8272pdXSMr9V0mnUxNh5Q0XOMTqK9OoW0FHVV8XSipVQjUpOPhp9z52CzS0hRsX8pCiCIlP2ICIYQoKs6nw5v/wrb423Zcu4F61Xf8r08tRrz0lEwKLgo9p0hc9OjRA19fX9tzR/9gbdmyhYkTJ9K1a1defPFFlixZcsf3eJj3rlGjRp6sNZ95B6127doOP3dhIu2Qt21w4RBgBL0KutepTmszLD9onffiO2NJ5lYviZ8OPomAyZcVLAFZflZMZjh7GbWrHldPV8ooRqq4KPhixstiokkpPb1qlKBKSVdAj1pd8qHqKp8FK2kHaYNMjmqHjIwMTpw44YgqPbC8jgmEEKIo2JsE719S+C0xy+9IiwK/7IHw45RNS2bdrKdo0zSgwOoohCM5ReIiNDTU9nzatGkOPfcXX3zBtGnT6NChAzNmzEClUuHl5YXBYMBoNKLT6WxlU1JSZEURUSwlm60Ze4A67qDBwpIVu9GmeEGLEDIUqLwhEkWnxehf9taYybQM2iVfZ3ygG9Wrl6ByeZ88GS4lhCg+8jImEEKIouC7GwpP/6NgVGWJuZJTYem3cPI8jzSuzLpZr1G+jPxdI4oOp0hc5JVZs2axZMkS+vTpwyeffIJWa73cKlWqoCgKERERVK1a1Vb+9tdCFBebbmSOiYRgVwsD39/M6i3HwK8ENG0AGjWGAP9bB9zM6D9tjmXtx73kjqgQQgghRD5YfMXIG5c0KJk3iqLjYPdh+PMQ9cq58+w7HRgzqDU6nawaIoqWIntrdOXKlSxZsoQBAwYwbdo0W9ICICQkBBcXF3bs2GHblpCQwL59+2jZsmVBVFeIAnMmDd7499brYxt2W5MWgCo2HvewQ3blNTfiKbnka/rGR/DF+K6StBBCCCGEyAczTyUx9LL2VtLiwN+0/f4HVrQsSdTPQzn23RuMe72NJC1EkVQke1xERUUxY8YMAgMD6dmzJ0ePHrXbHxwczIsvvsicOXNQq9UEBASwePFiPD09efrppwuo1kLkH5PJwsI9EYSnqPjdozTJWlcAXI/+w7E11pV1/r+9O4+zse7/OP46Z/bFDIbsDMOMXYNsJUSS0iJakBtFG3WnQUh0S4NbkzXLHZW6K0Lqd7faKmVQEZGdsUyWwRjObGfOnOv3x5jDNJTlzDln5ryfj4fHPed7fc91fa7PfeQzn3Nd38vPz8x7E7vz4J0N2Z8N6bngZ4LooNL4dOvlzvBFREREvMq49cd5xVbesQi674+bWVDXh0effdTNkYm4RolsXPzwww9YrVZ2797NQw89VGh7YmIiQ4cOxWw2s2DBAjIyMoiNjWXixIla40KKLcMw+P1IGjtOZZFz/r6PMJOdUJNBhmEiHTMWw8SW1BzmnvYjs3J1CL9oB8dOkTXvEwDKhgexKKEHndpEARAV6OKTERFxotTUVFq1alVo/I477mD69OkYhsGcOXNYtGgRqampNG3alJdeeomoqCjHXKvVypQpU/j888/JyMigbdu2jB49mgoVKjjmpKWlER8fz5o1a7Db7XTu3JmRI0cSGhrqkvMUkZLHkgv3rE5hTUgFx7XyYZu3k9i9KvWjrvbZ8yLFV4lsXHTv3p3u3bv/7by4uDji4uJcEJFInmx73lM6wnzA5zrusDh0Kp3hP6bwuRFKtq8fPtYcsv39MMqU/vs3BwKV/zR2Kg1mL4asbNrdVIP3J3enasXwS71bRKTY2blzJwDz588v0EQoXbo0ALNmzWLevHnExcVRpUoVZs+eTb9+/fjiiy8cX2iMHTuW1atXM2LECIKDg0lISGDQoEEsW7YMH5+8y7KHDBnCkSNHGDduHFlZWUyePJmTJ08yd+5c156wiJQIBzPs3LgukzMhFxoUFfbu57deNSlfJtiNkYm4nsc2Lvbv3096ejqGYRTa1rhxYzdEJHJtNlsgPhn+lwqZ9rwxXxNU8TPwseZgOZuB3WrDbLfjY7djtuditud97u1mEzm+fuT6+GAyDGzW0qT7+JLzhy+Ui3QcI+ca4go4lUoXI40oawbVrOn49WtG9crhdL21Dj4+JXb5GxEphq63Jti1axflypXjlltuKbTNYrEwf/58Bg8eTN++fQFo3rw5HTp0YMmSJfTv359Dhw6xfPlyXn/9dbp27QpA3bp16dKlC6tWraJz586sX7+eDRs2sHjxYpo0aQJAxYoV6devH9u3b6dBgwbXkwIR8RL5t+b+cTaLRuuysJxvsJJjo+X+XXzbuy6B/lrDQryPxzUu9u3bx3PPPce+ffsKbTMMA5PJ5HhevYgznbVkczLdis0AG2AzTOQYkAvkGHmvbed/tljt/HzUwq8p2ey0mjkeEILNbMZks4EBhp8Phq8vhp8v9pDCHXGbAQetJsAfwvyvL/CsbPD3x5STQ6mzZymXm42v3Q6YyPLzw+rrh1+uDX+bDX9bDgG5NjqX82VC12r4+pS5vmOLiBQhZ9UEu3btIiYm5pLbtmzZQkZGBh07dnSMhYeH06JFC9auXUv//v1Zv349AO3bt3fMiYyMpE6dOqxdu5bOnTuTmJhIRESEo2kB0LJlS0JDQ1m7dq0aFyJyWcnZ8FoyfJsGv2eCHwb2DIPc/KbFqTOMTE9iQr8mWhRdvJbHNS4mTpzI8ePHeeqpp6hSpQpms3d983vMCjOOwvGcvMdTZtjhqKUqNc1WZtsh0LvScUm7UzL48PfTZNkN7JgwgBy7wa4zOezJNMjAjGEyYZjP/+/5P1z0c952E3azDzYfH7L8/MkNDgRzwJUHYi4FFf5+moMlA46fghwblAqBMmHg7we+V9k1z7Xjm5lJzYw0Rtf0o2/rchiYMOGPyVTu6vYlIuLBnFUT7Nq1i4CAAB5++GG2b99OmTJlePTRR3n88cdJSkoCoFq1agXeU7VqVVavzlus+MCBA5QrV47g4OBCc/Lff+DAAapXr15gu9lspkqVKo45V2vv3r1FVgdlZmYCeP2XQd6eB28//4u5KxfJub70s9Qg2X7hi6wcTBAclPfiXDrjMnfyYJNwx21vRcnbPxPefv4Xc0Yu7Ha7s8LxvMbFzz//zKhRo7z26R4vH4b/HP/zaCm+A87thkUx17c2wpWyGbAjAyx2sKZnkWnJItBkEGAyCDDBaYuVlQfPsTXNhhUTuWYzNpOZXLMZAxOY8hov+QzOB11g3FRwjunCeL5ckwmb2Ydcs4mcrEBOmgI4UykQ/KoWDjrIWWd/Dez2vIaEn1/eas/ZVkw5NsixYU7PxP/n3whYvwWT9cJNHSZMxNarSK97GtOsSTVyDBNWA6yYsBl5WTADoWaDIJNBLrA3KYlaEYHEtm0IhFy0LxGRkscZNYHdbmffvn0EBQUxYsQIKlWqxHfffUdCQgLZ2dn4+fnh7++Pv3/Bq99CQkKwWCwApKenExISUmjfISEhHDt27G/n5O9HRORihZoWdjv8kQJ+vlAhArMlncnm/XRtpHXHRDyuceHn50fFihXdHYbbNAmy41gy+E+WnoZb16RSL6dgAXTxL//ZuQa7LbkcyvXBas77Jj+vIXD+ioPzP+b/qpt3JULe67xteVciZJQOx+7nd36vgef//EnZilD2Ws7Sw9hyIT2ToOxsAo1cTHY7ZsPAZLfn/Ww3MBl2THYD8/kxH8NOJX9oWMafW6uG0LVOGcoG+5N/+7XJ5A/kF8Fh8GAFoNN1h+qfnXLd+xARKS6cURPkPzGkcuXK1KhRA4BWrVqRkZHBW2+9xZNPPnnZS6/zx/NvS7nUvi+ec6mrIy43fiVq165NQMBVXAl4FfK/QatXr16R7L+48PY8ePv5X8zVudh4Dh7+zcap/F/HTpyGf78Lp9MAaNOyFotff4AqEY1cEk8+b/9MePv5X8wZucjOzmbbtm1OicfjGhdt27ZlzZo1tG3b1t2huMXRxWtg8RYodf5y1OwcqF4RBj4APmbWBZZhXeDfrEtQusjDdCtzahr1z53mBr+8novJyLueo1qID20qhxAVEYgfeVem+Pzpf00Yjp/NQIAp7+fyZYPx9b3+x9XptkMREedxRk3g4+ND69atL7nvjz76iKCgIKxWKzk5Ofg5GvZ5V1DkP1EkNDSU9PT0QvvIyMgoMCclpXBzOSMjQ49DFREAxh2CZachzMdgQ5qBzXz+V7GUVJj8DqSepWrFMHrf3YhXhnQgwN/jflUTcRuP+9tw7733Mnz4cDIzM2nevDlBQYWv/89f0bskyrLaIPVs3p98x0/lrYUw4D7XBZJ6FvYn42OxUDaiFEGlgrD7+JB7/o/JBDXMuTQOM1Pa14QfBn4Y+GNgLnAzyIX/vfh3+vybRAqPF5xvxiAQA18Mko8eJdjPxJA7m+Hvr0vmRERKOmfUBMePH+fbb7/l9ttvp2zZC5cJZmdnA3kLcRqGwZEjR6hZs6Zj+8WvIyMjOXnyJFlZWQQGBhaY06xZM8ecTZs2FTi23W4nOTmZbt26XeWZi0hJs/EcvHIk/5Up79ZigH2HqbbsSx7v3ZQH72xATM1yWoBT5BI8rnExaNAgAD755BM++eSTQttNJlOJbly8+txtNGtQmeMnL9wOcvx43qIX6Ye3kRwQ8qeVIfJc/At/TGk/OkSGUbNM4EUNgLyrARw/5/8xXfq1jykA2tciKNDPYx6NuWNH3rdd/noElIiIV3BGTWC1Wnn55ZfJzMykX79+jvGvv/6ayMhIbr/9dl5++WVWrlzJwIEDAUhLS2Pjxo0MHjwYgNatW5Obm8vq1asdx0tKSmLPnj0F5sydO5etW7c6HtG6YcMGLBbLJa/4EBHvMv/EnwZsubBuC0NMJ3l98WP4+am+FfkrHte4WLhwobtDcKvAAD8euavgvWy610pERLyRM2qCatWqcffddzNt2jRMJhNRUVF89dVXfPPNN8yaNYuQkBD69OnDtGnTMJvNREZGMmfOHEJDQx2LglavXp0uXbowZswYLBYLYWFhJCQkEBMTQ6dOeesXtWrViiZNmjB48GCGDx+OzWZj0qRJtG/fnoYNG173eYhI8ZWeC+8fP7+OnTUHRk4nCDsLXurCw3d1dnd4IsWCxzUuWrRo4e4QRERExAM4qyaYMGECb775Ju+++y4pKSlERUUxY8YMOnbsCMDQoUMxm80sWLCAjIwMYmNjmThxomP9CoD4+Hji4+OZMmUKdrudNm3aMHr0aHx88r4lNZlMzJ49m/HjxzNmzBj8/f3p2LEjo0aNcso5iEjxNeTLA2SUPX8r2i+/UzvMj2UzHqJRdAX3BiZSjHhc4wLybo2YMWMG69at49y5c5QpU4ZWrVrx1FNPUalSJXeHJyIiIi7ijJogMDCQoUOHMnTo0Etu9/X1JS4ujri4uMvuIzg4mPHjxzN+/PjLzomIiGDq1KlXFJOIlGyGAZ+esjPty11861va8SS+ZqePsfLjgZQOK7xmj4hcnsc1Lo4dO0aPHj04c+YMN954I+XLl+f48eMsXbqUVatWsWzZMipUUHdSRESkpFNNICLFVXySjdFHfSHqwq3eYRnpJI7rpPUsRK6BxzUu3njjDQCWL19O7dq1HeN79+6lf//+TJ8+nQkTJrgrPBEREXER1QQiUhx9sN/C6D+C81a8v8jL9YLx89MTQ0SuhWc8LuIia9eu5ZlnnilQoADUrl2bp556iu+//95NkYmIiIgrqSYQkeJiZ7qdfySm0mD5H/TZ7wvmvF+zfDdsZUBuCu/Whucrq2khcq087oqLzMxMqlatesltVatW5cyZM64NSERERNxCNYGIeLpVf2Ty1GYLe8LLgbkM3FDGsS1w70ESu1bgxpjyboxQpGTwuCsuatSoQWJi4iW3JSYmUrlyZRdHJCIiIu6gmkBEPNVxK9yZeI5O+wPZU6Y8mAteTVHm6DE23RHBjTFah0fEGTyucdGzZ08WLlzIvHnzSElJASAlJYV58+bx3nvvce+997o5QhEREXEF1QQi4onOWO00+DGTr4xSFxoWZy3U3vQrr5zayfZa5zjVvSL1KoS6N1CREsTjbhV5+OGHSUxMJCEhgTfeeAOTyYRhGBiGQYcOHRg0aJC7QxQREREXUE0gIp7m9JkMGv/fcU5F1cwbyMym5q+/8eVDUcR0udGtsYmUZB7XuPDx8WHmzJmsW7eOdevWkZaWRunSpWndujVt2rRxd3giIiLiIqoJRMSTbNx6hK5v/8apnnfmDWRZGbjzZ958rhW+vnrEqUhR8rjGRb42bdqoKBERERHVBCLiVoZhMOuDjTw/fwO20U84xv/pc4o3nrnZjZGJeA+PaFyMGzeOxx57jGrVqjFu3Li/nGsymRg7dqxrAhMRERGXUk0gIq523ArvZJWlrMmGfxbUCgDT+aUrrFYbz4z/grc++RVGDICgAAC6BVtJaFLJfUGLeBmPaFx89NFH3HPPPVSrVo2PPvroL+eqSBERESm5VBOIiCsZBvTYBT9k5j3948VN0DQEZtaCatYM7vr392w9kQt9u0FU3uOZq/sbLGzo72huiEjR84jGxc6dOy/5s4iIiHgX1QQi4kobLPDDuYJjm9KhzW9gyvHHuKdLgW1m4INoE6U94rcoEe/hcY9DFRERERERcYUZRy/83N4njcq5WY7Xhl/h7sTYanBzmCsiE5GLeUSv8O/uYb2YLgsVEREpuVQTiIir/GGFxafyfvazZvPTyLmkn8uCji2hU0vw8SH88B8807YaVcsGU90fupZxb8wi3sojGhd/dw/rxVSkiIiIlFyqCUTEFWwG/Ds5738Bctb8Qs6ZjLwX3yQS9P1P9LyjAdNH30l4qUD3BSoigIc0LnQPq4iIiIBqAhEpejOOwqtHDE7knF9d027A6o34+5l5sEtDendrRLubIgkK9HNvoCLi4BGNCxERERERkaJ2JBueO2BgcNEjQTb8xs1VA5k4uR23tI51X3Aiclke0bjQ/awiIiICqglEpGi9vysNg/C8F/uT4et1jGpejkdGt8XHR88tEPFUHtG40P2sIiIiAqoJRMR5jlkh2Axh53/j+eB/W3npdxvc0hSA4BU/8NGAG+nWIYYdO3a4MVIR+Tse0bjQ/awiIiICqglExDneOwED9kE5X1jX0ODd+d/yyqzvYPwzeRPsdn4YdzuxNcu6N1ARuSIe0bgQERERERFxhsRz8Pi+vCeGHMuBdl8c5fCs7yA0GCqXB6BJCGpaiBQjHtG4GDhwIC+++CJRUVEMHDjwL+eaTCbmzZvnoshERETElVQTiMj1OJAF9+8Eq3Fh7HClytCoDvj6OMbal9Z6FiLFiUc0Lvbt20dWVpbj579iMpn+cvvlrFq1iri4ODZv3uwY++233+jRo0ehuQMGDGDEiBHXdBwRERG5dkVdE1itVu69916aNGnCxIkTATAMgzlz5rBo0SJSU1Np2rQpL730ElFRUQXeN2XKFD7//HMyMjJo27Yto0ePpkKFCo45aWlpxMfHs2bNGux2O507d2bkyJGEhoZedZwicnXsBsw+Bi8eBIs9b8z3XDq2UiF5L3rdyW1hBqvPz28b5pYwReQaeUTjYvXq1Zf82Vk2bdrEsGHDCo3v2rWL4OBg3n777QLjN9xwg9NjEBERkb9X1DXBzJkz2b9/P02aNHGMzZo1i3nz5hEXF0eVKlWYPXs2/fr144svvqBUqVIAjB07ltWrVzNixAiCg4NJSEhg0KBBLFu2DB+fvG9xhwwZwpEjRxg3bhxZWVlMnjyZkydPMnfuXKefh4gUNGgfzD9x0cDJM9heewuefghqV4MbynLxf1HalnJ1hCJyPTyicVFUrFYr7777LtOmTSM4OJicnJwC23ft2kWdOnW48cYb3ROgiIiIuMzvv//Oe++9R5kyZRxjFouF+fPnM3jwYPr27QtA8+bN6dChA0uWLKF///4cOnSI5cuX8/rrr9O1a1cA6tatS5cuXVi1ahWdO3dm/fr1bNiwgcWLFzuaIhUrVqRfv35s376dBg0auP6ERbzEwqM25p+46NeaH3+FRV9DeibVV35PSu1eZHLhCq2YILjB3/Vxisi187jGhcViYdq0afzyyy+kpaUV2m4ymVi5cuUV7ev7779n3rx5DB8+nDNnzhS6smLXrl3ExMQ4JW4RERFxLmfWBDabjVGjRvHYY4+xYsUKx/iWLVvIyMigY8eOjrHw8HBatGjB2rVr6d+/P+vXrwegffv2jjmRkZHUqVOHtWvX0rlzZxITE4mIiChwJUfLli0JDQ1l7dq1alyIFJFf/rAwYKcfBJ7/tWbh/1H+tx3846FY7ukQQ+sbq7Ily8Q9O+EPa96UW3WbiEix43GNi7Fjx/L5559Tv359IiMjr3lNC4BGjRqxatUqwsLCmDFjRqHtu3fvxt/fn3vvvZd9+/ZRqVIlnn76ae6///5rOt7evXsxm52/0E9mZiaA1z9fWnlQDvIpD3mUB+Ugn7PyYLfbnRGO0zizJvjPf/5DTk4OgwYNKtC4SEpKAqBatWoF5letWtVxq8qBAwcoV64cwcHBhebkv//AgQNUr169wHaz2UyVKlUcc65WUdUVoL87+bw9D8X9/BMPWHjiXFVyq1UCwLx5B8Nr23nwyTsJDPAFMtizZzfBwH+DfBlnVOSo3Y/7M5PZscNaYF/FPRfO4u158Pbzv5gzcuHMusLjGhc//PADTzzxBM8///x17+viBbP+7Pjx46SmpnLw4EGGDh1KeHg4//vf/3jxxRcxmUzcd9991318ERERuXbOqgn27dvHnDlzeOedd/D3L3h9uMViwd/fv9B4SEgIFosFgPT0dEJCQgrtNyQkhGPHjv3tnPz9iIjzvL0plSlh9TGqlQbAnHaOudXTuLl29CXnVzDbmB16xIURiogzeVzjAqBZs2ZFfoywsDDeeustYmJiHItxtmnThhMnTjBz5sxralzUrl2bgIAAJ0d6octVr149p++7OFEelIN8ykMe5UE5yOesPGRnZ7Nt2zZnhOQ011sT2O12Ro8eTY8ePYiNjS203TCMy17JkT9+uTkXjxuGccmrIy43fiWKqq4A/d3J5+15KI7nv8kCjyeeZnONumDO+/vnm57Bp/VNdK3R6pr3WxxzURS8PQ/efv4Xc0YunFlXeNwDjLt06cJXX31V5McJCgqibdu2hZ4g0rZtWw4fPkx6enqRxyAiIiKX54ya4L333uOPP/7g2WefxWazYbPZgLyGgs1mo1SpUlit1kILeKenpzueKBIaGnrJuiAjI+OK5uhxqCLX76gV+u0xaLYVNoeUdTQtws+cYVsLX7rW0N8zkZLM4664GDFiBA899BC9evUiNjaWoKCgAttNJhPPPPPMdR/nwIEDrF+/ngceeKDA5aHZ2dkEBgYWuo9VREREXMsZNcHKlSs5fvw4LVq0KDC+c+dOli9fzr/+9S8Mw+DIkSPUrFnTsf3i15GRkZw8eZKsrCwCAwMLzMm/IiQyMpJNmzYVOIbdbic5OZlu3bpd/cmLiMOODLj5N4PU3IuufDqXTutTf/BVzyjC/Dzuu1gRcTKPa1wsWbKEPXv2ABQqAMB5jYvjx48zbtw4ypUrx+233w7kffvyzTff0Lx58+taAExERESunzNqgldeeaXQlRBxcXHUrFmTZ555hpo1azJhwgRWrlzJwIEDAUhLS2Pjxo0MHjwYgNatW5Obm8vq1asdj0NNSkpiz549BebMnTuXrVu30rhxYwA2bNiAxWKhdevW15EFEe9mGPDkPjupueebE5nZ8H/f8UrDEMY81kY1u4iX8LjGxYIFC2jTpg1xcXGFbuNwpptuuolmzZoxduxY0tLSKF++PIsWLWLXrl188MEHRXZcERERuTLOqAlq1apVaCwwMJDSpUvTqFEjAPr06cO0adMwm81ERkYyZ84cQkND6dmzJwDVq1enS5cujBkzBovFQlhYGAkJCcTExNCpUycAWrVqRZMmTRg8eDDDhw/HZrMxadIk2rdvT8OGDa8xAyLy3h85fH/OL+/FqTOYJrzFvBc68HjPol8TT0Q8h8c1LlJTUxkwYAD169cv0uP4+Pjw5ptvkpCQwPTp0zlz5gz169fn7bffdhQyIiIi4j6uqgmGDh2K2WxmwYIFZGRkEBsby8SJEx3rVwDEx8cTHx/PlClTsNvttGnThtGjR+Pj4wPkXf0xe/Zsxo8fz5gxY/D396djx46MGjWqSGMXKYk+Ow399xj45ORwOjsXgvIaF75LV/Lxq3dxXyctnCjibTyucVGvXj0OHz7s9P0OGTKEIUOGFBgrXbo0//rXv5x+LBEREbl+RVUTfPrppwVe+/r6EhcXR1xc3GXfExwczPjx4xk/fvxl50RERDB16lRnhSnilb5PSqPHoWByfP3A7A/nl7bx2Z3Eiqea075lpFvjExH38LjGRVxcHEOHDiUgIIBmzZoREhJS6N61iIgIN0UnIiIirqKaQMR72O12Xp75HRPK1Iao8ALbTFnZLGoWQvtG5d0UnYi4m8c1LgYPHkx6ejqjR4++7Jz8Z8qKiIhIyaWaQMQ7rEnJoe/KPzhSrQlUKJs3eCqNnr/8yE3t6nN/8yrUDlPTQsSbeVzjonfv3lodWERERFQTiHiBXSczuP03H3Jr1HCMmQyDT2/0o1u3rm6MTEQ8icc1Lv68DoWIiIh4J9UEIiXbiVMWWi89Qm6junkDubnUNOUwpV4g3SKC3RuciHgUs7sDEBERERER75J8/CzNR31N6vmmhSkrmy9Kp7D/lkC6a+kaEfkTNS5ERERERMRlDhxJpfnorznc9TbH2LByVu5sVNGNUYmIJ/O4W0VERERERKRkWncglU5fHSdzQE/HWIyvjQmNSrkxKhHxdLriQkREREREipRhwNidmdySFEJmk7qO8Xp+uXzWyBdfrcMrIn/B4xoXM2bMYPfu3e4OQ0RERNxMNYFIyTF9fyb/Oh2EEeAPgDkziwnlstja3IfoIDcHJyIez+MaF2+99RaHDh1ydxgiIiLiZqoJREqGpJPpxO2zO16H/rKNX2KsjIoO1JUWInJFPG6Ni+rVq3Py5El3hyEiIiJupppApHg6lwubLfB7pkH64RQm/5CMrWUsAAE797HlvsrUqhrm5ihFpDjxuMbFo48+Snx8PNu2bSM6Oppy5coVmtO1a1c3RCYiIiKupJpApPiZcRSGJhnYDBNgAm6Aljfkbcy1s+yWstSqVsadIYpIMeRxjYuXX34ZgCVLllxyu8lkUpEiIiLiBVQTiBQvB7Ig7oCBjUvf//FwSBZdo9W0EJGr53GNi4ULF7o7BBEREfEAqglEipd/bLJgJTTvxY4D8NseIprWIb1WdeqGmJjZMNi9AYpIseVxjYsWLVq4OwQRERHxAKoJRIqPhPVHWUulvBfnMoj99jsShrSjfYua7g1MREoEj2tcAGRlZfHBBx/w/fffc/z4caZPn873339PbGwsTZs2dXd4IiIi4iKqCUQ839cbDxKXHEx+36L+tt9Y91ZvAgP83BuYiJQYHvc41DNnztCzZ0/+/e9/c+zYMZKSkrBaraxdu5b+/fuzZcsWd4coIiIiLqCaQMTz/bjpEHetO4tRqTwAoadPs+GZpmpaiIhTeVzjIiEhgZSUFJYtW8b//vc/DMMAYObMmURFRTFr1iw3RygiIiKuoJpAxHMlZcG4Tafp8M0Jcls0AsBss7H65lKEBqppISLO5XGNi1WrVvHss89Sr149TKYLKxKHhoby2GOP8dtvv7kxOhEREXEV1QQinmlnBjTYZOeVrLLk3NrcMT43Cm4qo6aFiDifxzUuzp07R9WqVS+5LSwsjPT0dBdHJCIiIu6gmkDE8+Qa8Mj2HDL+9GvEM+VsPF7FI5fPE5ESwOMaF5GRkaxZs+aS2xITE4mMjHRtQCIiIuIWqglEPM+EPVn8mnP+qoqUVKK+XM3aOtnMjFbTQkSKjsf9F6ZXr1688sor+Pj40KlTJ0wmE8nJyfz000+8//77jBgxwt0hioiIiAuoJhDxLMv/yGbcHz7gn/c6cuVafnr1dsqEB7g3MBEp8TyucfHwww9z8OBB3n33Xf773/9iGAbPPfcckFfA9O7d280RioiIiCs4qyawWq3MmjWLzz77jNTUVBo3bsyIESNo0KABAIZhMGfOHBYtWkRqaipNmzblpZdeIioqqsA+pkyZwueff05GRgZt27Zl9OjRVKhQwTEnLS2N+Ph41qxZg91up3PnzowcOZLQ0FAnZkXE9WwGvJKUy6t/+IN/3nozIT//xtrR7SgTHuTm6ETEG3hc4wJgxIgR9OrVi8TERE6fPk1YWBitWrWiVq1a7g5NREREXMgZNUF8fDyffvopcXFxVK9enffee4++ffvy2WefUaVKFWbNmsW8efOIi4ujSpUqzJ49m379+vHFF19QqlQpAMaOHcvq1asZMWIEwcHBJCQkMGjQIJYtW4aPjw8AQ4YM4ciRI4wbN46srCwmT57MyZMnmTt3bpHkRsQVNlngsT12fs30gfNr5PruTmJNl4pUrRju3uBExGt4ZOMCoFq1avj6+pKWlkZERATly5d3d0giIiLiBtdTE5w7d46PP/6YF154gV69egHQvHlzWrZsyaeffkrfvn2ZP38+gwcPpm/fvo7tHTp0YMmSJfTv359Dhw6xfPlyXn/9dbp27QpA3bp16dKlC6tWraJz586sX7+eDRs2sHjxYpo0aQJAxYoV6devH9u3b3dc3SFSHGy2wNjD8PM5O0dtZhzL4tkNfL5cy6rukdwUrdpcRFzH4xbnBPjiiy+4/fbbue2227j//vu59dZbue+++1i/fr27QxMREREXut6aICgoiMWLF9O9e3fHmK+vLyaTCavVypYtW8jIyKBjx46O7eHh4bRo0YK1a9cCOI7Vvn17x5zIyEjq1KnjmJOYmEhERISjaQHQsmVLQkNDHXNEioMdGXDbdoP/S+V80+K8oycxv/4OS2+7gVubVXdfgCLilTzuiotvvvmGoUOHEhUVxTPPPEO5cuU4ceIEX3zxBY8//jgLFy6kadOm7g5TREREipgzagJfX1/q168PgN1uJzk5mRkzZmAymbjnnntITEwE8q7quFjVqlVZvXo1AAcOHKBcuXIEBwcXmpOUlOSYU716wV/mzGYzVapUccy5Wnv37sVsLprvmDIzMwHYsWNHkey/uPD2PPz5/E/ZfXjobA3OGOcX28zKhj9SMP26i9vPHuLxAdFEVzZKZL68/bOQz9vz4O3nfzFn5MJutzsrHM9rXMyZM4ebb76Z//znPwX+sR48eDADBgxg6tSpLFy40I0RioiIiCs4uyZ48803mTFjBgDPPvsstWrVYsWKFfj7++Pv719gbkhICBaLBYD09HRCQkIK7S8kJIRjx4797Zz8/Yh4sizDxFNnq/JHftMi+QRMnE/31pV55qGGVCpX2b0BiohX87jGxb59+3jjjTcKfcNgNpvp06cPw4YNc1NkIiIi4krOrgk6depEixYt2LBhA2+++SY5OTkEBgZiMpkuOT9/3DCMS865eNwwjEteHXG58StRu3ZtAgKK5jGT+d+g1atXr0j2X1x4ex7yzz+mbj0e2GFnm3H+s3rmHKH/+Ziv3+pNm1jvuC3E2z8L+bw9D95+/hdzRi6ys7PZtm2bU+LxuMZF+fLlOX78+CW3WSwWSpcu7dqARERExC2cXRPUrVsXgBYtWpCens78+fOJi4vDarWSk5ODn5+fY256errjiSKhoaGkp6cX2l9GRkaBOSkpKZeco8ehiqcbtj+X5Wfyno5DtpXg/3zMisn30OrGan/9RhERF/G4xTmfeuoppk2bxubNmwuMHzhwgBkzZvDMM8+4KTIRERFxJWfUBCkpKSxdurTQ7Rr16tXDarUSHh6OYRgcOXKkwPYjR45Qs2ZNIG8hzpMnT5KVlfWXcw4fPlxge/6aGvlzRDzR2sxAEo6fb1rYDQLe/ZRvxnRS00JEPIrHXXGxYsUKDMOgV69e1K5dm4oVK3L69Gl27dqFYRgsWLCABQsWAHmXcH7++edujlhERESKgjNqgrNnzzJq1CgAHnjgAcf4jz/+SEREBJ06dSIgIICVK1cycOBAANLS0ti4cSODBw8GoHXr1uTm5rJ69WrH41CTkpLYs2dPgTlz585l69atNG7cGIANGzZgsVho3bp1EWVI5Pqcsxn880QEhOW99vtsNSsGt+Dmpt5xe4iIFB8e17hIT08nOjra8TorK4vg4GBiY2PdGJWIiIi4mjNqgqioKO644w4mTZpETk4O1apV45tvvuHTTz/ltddeIzQ0lD59+jBt2jTMZjORkZHMmTOH0NBQevbsCUD16tXp0qULY8aMwWKxEBYWRkJCAjExMXTq1AmAVq1a0aRJEwYPHszw4cOx2WxMmjSJ9u3b07BhQ+cmRsQJDMOg78+QGZPXtTDtP8IX3WvRtnkNN0cmIlKYxzUu3nvvPXeHICIiIh7AWTXBpEmTmDlzJvPmzePEiRPUrl2badOm0aVLFwCGDh2K2WxmwYIFZGRkEBsby8SJEx3rVwDEx8cTHx/PlClTsNvttGnThtGjR+Pjk3eJvclkYvbs2YwfP54xY8bg7+9Px44dHVd7iHiaB9/fzq46DfJe5NiYVimbTq2i3BuUiMhleFzjoqisWrWKuLi4AvfJGobBnDlzWLRoEampqTRt2pSXXnqJqCj9R1tERKSkCAoKYtiwYZd9Comvry9xcXHExcVddh/BwcGMHz+e8ePHX3ZOREQEU6dOvd5wRYrcM0t3sKRGPTDnPRXnvqwTDLlD9a+IeC6PW5yzKGzatOmSxcqsWbOYPXs2AwYMICEhgXPnztGvXz/OnTvnhihFRERERIqOYcDjK5J5s2wU+OZdLRRz/DBLO1d2c2QiIn+tRDcurFYr//nPf+jbty++vgUvLrFYLMyfP5/BgwfTt29fOnbsyPz580lPT2fJkiVuilhERERExPlO5kDTdRnMD6kCAf4AVDn+B4uiz+VfeCEi4rFKdOPi+++/Z968eQwfPpw+ffoU2LZlyxYyMjLo2LGjYyw8PJwWLVqwdu1aV4cqIiIiIlIktu4/SeNVZ/jVFOwYq3XkEMvrpOGvroWIFAMleo2LRo0asWrVKsLCwpgxY0aBbUlJSQBUq1bwGdVVq1Zl9erV13S8vXv3YjY7vxeUmZkJwI4dO5y+7+JEeVAO8ikPeZQH5SCfs/Jgt9udEY6IeIiNW4/w6rwf+L+YxtCsft7guQxu+vknfhx+C3v37nZvgCIiV8gjGxc2m42zZ89StmxZDMPgo48+4vDhw9x55500atToivdToUKFy26zWCz4+/vj7+9fYDwkJASLxXLNsYuIiIjzOKsmEPEmubl2/hn/FTO/2An/uAca1c7bYM2h668b+XhoG/z8fNwbpIjIVfC4xsX+/ft57LHH6NatG0OHDuWNN95g3rx5ACxcuJC3336bm2666bqPYxgGJtOlL4273PjfqV27NgEBAdcT1iXlf4NWr149p++7OFEelIN8ykMe5UE5yOesPGRnZ7Nt2zZnhOQUrqoJREqSzKwceg9byicpBvzraQgOBMBkGLxdI4d/tG/v3gBFRK6Bx61xMXXqVEwmEx06dCA3N5dFixZxxx13sHHjRlq1asXMmTOdcpxSpUphtVrJyckpMJ6enl7gue0iIiLiHq6qCUSKO8OAZ/ZDlY126s3emte0ePpBR9PiBl+DT+uZ+EfN4L/Zk4iIZ/K4xsXGjRt5/vnniY2NZcuWLaSlpfHggw8SFhbGI4884rRvgmrUqIFhGBw5cqTA+JEjR6hZs6ZTjiEiIiLXzlU1gUhxtyIN3jwGf9jMHGzZDJ59xPG403vKwPZYE93KujlIEZHr4HGNi8zMTMqXLw/AunXr8PPzo3nz5gD4+/tjGIZTjhMbG0tAQAArV650jKWlpbFx40Zat27tlGOIiIjItXNVTSBSnBkGDNuTc8lt95aFJTFQzs/FQYmIOJnHrXFRuXJlfvvtN1q1asXKlSsdDQaA1atXU7VqVaccJyQkhD59+jBt2jTMZjORkZHMmTOH0NBQevbs6ZRjiIiIyLVzVU0gUpzN2ZHG1pzwvBfHT+NnMsi5IYKupeGjaPDzuK8pRUSunsc1Lrp168a0adNYtmwZBw4cYPLkyQAMHjyYVatW8dJLLzntWEOHDsVsNrNgwQIyMjKIjY1l4sSJWuNCRETEA7iyJhApbrLtMG97Ks/vs8MNeWOVf9zI+rg22EpDZABc43rzIiIex+MaF08//TR+fn5s3LiRRx55hHvuuQfIe3zp0KFD6d279zXtd8iQIQwZMqTAmK+vL3FxccTFxV133CIiIuJcRVUTiBRnmbl561lMOJRLqlHG0bQIPHGKX168hYrlQt0boIhIEfC4xgXAwIEDGThwYIGxd955xz3BiIiIiNuoJhC54Jsz0H8v/GEF8HGM+2Rm8mmLECqWC3RXaCIiRcojGxcAX3/9Nd9//z3Hjh1jzJgx/Prrr8TGxlKjRg13hyYiIiIupJpAvJ3NgJcPQXzynzZs3kmdPw7z7bBbqFxaTQsRKbk8rnGRnZ3Nk08+SWJiIkFBQWRlZZGens7SpUuJj4/ngw8+ICoqyt1hioiISBFTTSACaTZ4cJfBN2kXLVix8wAs+oa25f34fG5vSoUEuC9AEREX8Lh1hqdNm8bmzZuZOXMmGzZscDzqLD4+nvDwcGbOnOnmCEVERMQVVBOIt9ufYafBuqwLTQu7HZatgikL6Vg5kC/n9VHTQkS8gsc1Lr744gsGDx5Mp06d8PG5cO9e1apVefLJJ/npp5/cGJ2IiIi4imoC8WbHz2bRZHUayb7nbwHJyIKE9whevZ6nH27O/83uRUiwv3uDFBFxEY+7VeTUqVPExMRccluFChVIS0tzcUQiIiLiDqoJxFv9ceIsTT4+hCW2Yd7AyTNEL/+SEb0b0bPLw7rKQkS8jsddcVG5cmV+/vnnS27bsmULlStXdnFEIiIi4g6qCcQb/b73BE3+9R0n85sWNhsJoansnP8wAx5oqqaFiHglj7vi4v7772fWrFmULl2aTp06AWC1WlmxYgULFixgwIABbo5QREREXEE1gXib7386SJcPd5L5YFfH2IvhGTzfpKYboxIRcT+Pa1wMHDiQ33//nUmTJjF58mQAevXqBUC7du0YNGiQO8MTERERF1FNIN5iXxaM25jCf/cZGD3ucIzfGZzDa43D3BiZiIhn8LjGhY+PD9OnT2fDhg2sW7eO06dPExYWRps2bbj55pvdHZ6IiIi4iGoC8QbfnIG7t9vJ8S0PMeUd4wPL2pgV7YfJdPn3ioh4C49rXORr2bIlLVu2dLzOzMx0YzQiIiLiLtdbE+Tm5rJw4UIWL17M0aNHqVy5Mr169aJ3796YTCYMw2DOnDksWrSI1NRUmjZtyksvvURUVJRjH1arlSlTpvD555+TkZFB27ZtGT16NBUqVHDMSUtLIz4+njVr1mC32+ncuTMjR44kNDT0+pMgJdKKM3D3Njs55gvLzgVkZjK9nj+DKntsmS4i4nIetzgnwIcffshXX30FwLZt27jlllto2rQpgwcPJisry83RiYiIiKs4oyZ48803SUhI4J577mH27NnceeedvPbaa7z11lsAzJo1i9mzZzNgwAASEhI4d+4c/fr149y5c459jB07lk8//ZQXXniB+Ph4du7cyaBBg8jNzXXMGTJkCBs3bmTcuHGMGjWK1atX88ILLzgxG1KSJJ416Lot90LTYstu7v9uJedu9WdQZZ+/frOIiJfxuMbFO++8w7/+9S92794NwIQJE7Db7fTp04fExERmzpzp5ghFRETEFZxRE9jtdt5++20ee+wxnnrqKVq3bs2QIUN46KGHWLBgARaLhfnz5zN48GD69u1Lx44dmT9/Punp6SxZsgSAQ4cOsXz5csaOHUv37t3p0qUL8+bNY9euXaxatQqA9evXs2HDBt544w3uvPNO7r//fhISEvj222/Zvn170SVJiqWkTDudNlmxmc83KLbu5tlzSSx9sSN+fmpaiIj8mcc1LpYuXcrDDz/Ms88+S0pKCps3b+bpp59m9OjRPPvss3z55ZfuDlFERERcwBk1wblz57jvvvvo3LlzgfGaNWty+vRp1q9fT0ZGBh07dnRsCw8Pp0WLFqxduxbIa0oAtG/f3jEnMjKSOnXqOOYkJiYSERFBkyZNHHNatmxJaGioY454t/+dhjqbIOonOw3WZZPhf/6xpnsOMdZ0nKnDbsekBS1ERC7J426eO3jwIKNGjQJg3bp1mEwm2rVrB0B0dDQnTpxwZ3giIiLiIs6oCcLDw3n55ZcLja9Zs4aKFSty/PhxAKpVq1Zge9WqVVm9ejUABw4coFy5cgQHBxeak5SU5JhTvXr1AtvNZjNVqlRxzLlae/fuxWwumu+Y8tcJ2bFjR5Hsv7hwRR4MA97LLsOkjAoYJhNghqCgvI0nzzA07Xceur0GO3fuLLIYLkefgwuUizzengdvP/+LOSMXdrvdWeF43hUXISEhpKenA3lFSsWKFR3FxNGjRylTpow7wxMREREXKaqa4OOPP2bdunU8/vjjWCwW/P398ff3L3Rsi8UCQHp6OiEhIZeM72rmiHcadSSYiZkVzzctgNzzhfy5dJ4/vY3Hb6/hvuBERIoJj7viokGDBixYsICsrCy+/vprunfvDsD27duZM2cOzZo1c3OEIiIi4gpFURN89tlnjB07ljvuuIM+ffowd+7cy16enz9uGMYl51w8bhjGJa+OuNz4lahduzYBAQHX9N6/k/8NWr169Ypk/8VFUeThwxT4LBUeKGvwyY8H+LT8RY2Jr36kwnfruff+ZjxxdwOa3nGL0457LfQ5uEC5yOPtefD287+YM3KRnZ3Ntm3bnBKPx11xMWLECA4dOkRcXBzh4eE88cQTAAwcOJCsrCyee+45N0coIiIiruDsmuCdd95h+PDhtG/fnilTpmAymShVqhRWq5WcnJwCc9PT0ylVqhQAoaGhjis/LpaRkXFFc/Q4VO+x4gz02gMfnYSeu018UL6WY1vFNet4/6ZSHF75T+b+sz1Na5d3X6AiIsWMx11xUadOHb7++mv27dtHdHQ0gYGBALz22ms0bdqUsLAwN0coIiIiruDMmiAhIYG5c+dy3333MWHCBHx980qgGjVqYBgGR44coWbNmo75F7+OjIzk5MmTZGVlOWLIn5N/1UdkZCSbNm0qcEy73U5ycjLdunW7tgRIsXIyB/6x59LbGv5xiF+GtcTfX08MERG5Fh53xQXk3Q/auHHjAsVB+/btCQsLu+S3GSIiIlIyOaMmePfdd5k7dy59+/Zl4sSJjqYFQGxsLAEBAaxcudIxlpaWxsaNG2ndujUArVu3Jjc317FYJ0BSUhJ79uwpMCclJYWtW7c65mzYsAGLxeKYIyWXYcBje+Fo/oU7B5Lh6EkAYrPT2NS9upoWIiLXweOuuMjNzeWjjz4iMTERq9WKYRhA3rcWmZmZ7Nixg82bN7s5ShERESlqzqgJTpw4wZQpU4iOjuauu+5iy5YtBbY3bNiQPn36MG3aNMxmM5GRkcyZM4fQ0FB69uwJQPXq1enSpQtjxozBYrEQFhZGQkICMTExdOrUCYBWrVrRpEkTBg8ezPDhw7HZbEyaNIn27dvTsGHDIsiOeJI5xww+Sz2/Dkp6JsxaRLUgM7OnPkLX1hXQU05FRK6PxzUuZs6cyezZswkNDSU3Nxc/Pz98fHxITU3FbDbTq1cvd4coIiIiLuCMmuCHH37AarWye/duHnrooULbExMTGTp0KGazmQULFpCRkUFsbCwTJ050rF8BEB8fT3x8PFOmTMFut9OmTRtGjx6Nj0/et+gmk4nZs2czfvx4xowZg7+/Px07dnQ8zlVKrq1ncxmyFzj/WeDdz+gQXZZFCT0pX7bwk2ZEROTqeVzj4vPPP6dLly4kJCQwffp0Tpw4wWuvvcbmzZsZNGgQtWvXdneIIiIi4gLOqAm6d+/ueBrJX4mLiyMuLu6y24ODgxk/fjzjx4+/7JyIiAimTp36t8eSkmPXqUxuXpdJbkTZvIHvN/HPBuH8e1gPfH11a4iIiLN43BoXR48e5d5778VsNlO/fn3HJZ2xsbEMGDCAJUuWuDlCERERcQXVBOKpjmTD+N8t1P/VhCW/aXH8FLOizbwxsouaFiIiTuZxjQtfX1/HM8urV6/OwYMHsdlsANx4440cPnzYneGJiIiIi6gmEE/z1alcKv9gpdov8PKZUOxBeYvGmjKymFs5i6e73+jeAEVESiiPa1zUrl2bn3/+GcgrUux2O7t37wYgNTWV3Nxcd4YnIiIiLqKaQDxFRqaVh5fu4c7f4ajZv8C20B17WVszg0Etq7gpOhGRks/j1ri4//77efXVV8nNzeX555+nVatWvPTSSzz00EMsWLCAunXrujtEERERcQHVBOIJtu5L4bblhznVuumFwUNH8dmVRLvAHD5+ojllSwe7L0ARES/gcY2LXr16cfLkSQ4ePAjAyJEj+cc//sHYsWMJDw9n8uTJbo5QREREXEE1gbjb61/uZnhaKewXNS2q7NzNG1VtdB3WjJBg/794t4iIOIvHNS4Ann32WcfPderUYcWKFezfv59atWoREqLHSomIiHgL1QTiDlnZNrp8sJPvImMg3C9v0G5ncJCF6f2jMZncG5+IiLfxuDUuAH766ScSEhIcr/ft28fUqVMd97WKiIiId1BNIK628/AZKi06zHcxDSEgr2kReu4cq6JtzGgWpqaFiIgbeFzjYu3atfTv358ffvjBMWY2mzly5Ah9+/Zl06ZNboxOREREXEU1gbjaR9/vo+EP6ZypXdMx1vrcCf7oGMptN+i2EBERd/G4xsWsWbNo27Ytixcvdow1bNiQL774grZt2zJt2jQ3RiciIiKuoppAXMFuwKyjBpEr0ngktxq5NfKeDmLKthIfcJJ1d9xAKV9dZiEi4k4e17jYvXs3vXr1wte34PIbPj4+PPTQQ/z+++9uikxERERcSTWBuMJsSxkGHzBxMCQcAvKuqvDPzOKbGDsvNivn5uhERAQ8cHFOf39/Tp06dcltZ8+edeqxUlNTadWqVaHxO+64g+nTpzv1WCIiInJ1XFkTiHf6OsXELPMNF77KSz1LA3smyzuWp3awx32/JyLitTyucdGiRQvmzJnDLbfcQrlyF7rcp0+fZt68edx0001OO9bOnTsBmD9/PqGhoY7x0qVLO+0YIiIicm1cWROI9ziWZefFTWdI/CODPSFVITyvQeG7Yh0ftAyn510N3ByhiIj8mcc1Lp577jl69OjB7bffzk033US5cuU4deoUP/30EyaTqcDK4tdr165dlCtXjltuucVp+xQRERHncGVNICXbCSskpWYyYVUS/ysfiT2kLFQu69juf+gPfnywFs3rVXRjlCIicjke17iIiopi6dKlzJo1i40bN5KamkpYWBi33norQ4YMISoqymnH2rVrFzExMU7bn4iIiDiPK2sCKZkMAwbtg7dOAARBZL1Cc4LOnWNt+9I0qxjs8vhEROTKeFzjAqBWrVq8/vrrRX6cXbt2ERAQwMMPP8z27dspU6YMjz76KI8//jima3hI9969ezGbnX8/ZGZmJgA7duxw+r6LE+VBOcinPORRHpSDfM7Kg91ud0Y4TuWqmkBKpimHc3nrhE+h8fIHDzEkLIumN+RQo5qZhhULNzRERMRzeGTjwhXsdjv79u0jKCiIESNGUKlSJb777jsSEhLIzs5m8ODB7g5RRERERK7R/C0nGX6u7IWFNzftoFKQmXG3VGZg6+qYTGp6iogUF17buDAMgzlz5lC5cmVq1KgBQKtWrcjIyOCtt95i4MCBBAQEXNU+a9eufdXvuRL5/6jWq+fd3wYoD8pBPuUhj/KgHORzVh6ys7PZtm2bM0IScZvcXDv/WLyT/95QC4LyuhbmVeuZVCWXof1aF8nVsSIiUrS89r/cPj4+tG7d2tG0yNe2bVsyMzM5ePCgmyITERERkauVa8CSAxaqvLOX/9aoD0GBAAQfSmZjz0jiBtyspoWISDHltf/1Pn78OIsWLeL06dMFxrOzswEoU6aMO8ISERERkauUlAU112XT82gox+tFO8ZrnzzOgXtuoFldPS1ERKQ489rGhdVq5eWXX+azzz4rMP71118TGRlJ+fLl3RSZiIiIiFypQ+m5xK7L4LDpott1c2w8wSl2d6vADcF+7gtOREScwiPWuNi6detVzW/cuPF1H7NatWrcfffdTJs2DZPJRFRUFF999RXffPMNs2bNuu79i4iIyNVzR00gxY/dgE+SLLy/4wxf2UPJKls6b8OJ0zTctZOlA5oQXT7CrTGKiIjzeETj4sEHH7yix48ahoHJZHLaCtATJkzgzTff5N133yUlJYWoqChmzJhBx44dnbJ/ERERuTruqgmkeEjJsPHkDyl8YQ8lK6wUlA69sPF0GsNS9zJxWCutZSEiUsJ4ROMiPj7eLccNDAxk6NChDB061C3HFxERkYKKuiZYtWoVcXFxbN682TGW/6SxRYsWkZqaStOmTXnppZeIiopyzLFarUyZMoXPP/+cjIwM2rZty+jRo6lQoYJjTlpaGvHx8axZswa73U7nzp0ZOXIkoaGhyPWb/fMxnjsRTE7pSoW2+Z5K5e2KGfS5u4UbIhMRkaLmEY2L+++/390hiIiIiAcoyppg06ZNDBs2rND4rFmzmDdvHnFxcVSpUoXZs2fTr18/vvjiC0qVKgXA2LFjWb16NSNGjCA4OJiEhAQGDRrEsmXL8PHxAWDIkCEcOXKEcePGkZWVxeTJkzl58iRz584tsnMq6WwGLE/OYlRiCnsqVYHSF66kCNx/iPamdB6uW5qH76xAgK8WVhcRKak8onHxZzabjb1792K1Wh1jdrudzMxMNm7cyHPPPefG6ERERMRVnFETWK1W3n33XaZNm0ZwcDA5OTmObRaLhfnz5zN48GD69u0LQPPmzenQoQNLliyhf//+HDp0iOXLl/P666/TtWtXAOrWrUuXLl1YtWoVnTt3Zv369WzYsIHFixfTpEkTACpWrEi/fv3Yvn07DRo0cGZavMKudDudf87ikF8wVKnmGA/+4zgzK1v5R6+quiVERMRLeFzjYuvWrQwZMoQTJ05ccrvZbFbjQkRExAs4qyb4/vvvmTdvHsOHD+fMmTO8/fbbjm1btmwhIyOjwPpW4eHhtGjRgrVr19K/f3/Wr18PQPv27R1zIiMjqVOnDmvXrqVz584kJiYSERHhaFoAtGzZktDQUNauXavGxVUwDJj82xlGnw4m1z/4woZsKx3PHuOzblUIDvBxX4AiIuJyHte4mDZtGjabjWHDhvHtt98SGBhIu3btWL16NYmJiXz44YfuDlFERERcwFk1QaNGjVi1ahVhYWHMmDGjwLakpCQg72ljF6tatSqrV68G4MCBA5QrV47g4OBCc/Lff+DAAapXr15gu9lspkqVKo45V2vv3r1FdkVBZmYmgMctbnogw+DJpFIcrlQN/M8PHj9Fg99+ZWK7MkRFB3Fw/26nHc9T8+Aq3n7+F1Mu8nh7Hrz9/C/mjFzY7XZnhYPHXV+3detWnn76aQYMGEDXrl2xWq307t2b+fPn07p1axYuXOjuEEVERMQFnFUTVKhQgbCwsEtus1gs+Pv74+/vX2A8JCQEi8UCQHp6OiEhIYXee7Vz5K/N+T2Lu1Nr5TUtzgvaupPX03/j456VibohyI3RiYiIO3ncFReZmZmOVbxr1qzJrl27HNt69OjBv//9b3eFJiIiIi7kipog/7Gql5I/frk5F48bhnHJqyMuN34lateuTUBAwDW99+/kf4NWr169Itn/lUpNy+Trnw4yeU8Wmxs2AZ/zubJkcO/xA/y3bx1CgusW2fE9JQ/u4u3nfzHlIo+358Hbz/9izshFdnY227Ztc0o8Hte4iIiI4PTp0wBUr16dM2fOcPr0acqWLUvp0qU5deqUmyMUERERV3BFTVCqVCmsVis5OTn4+fk5xtPT0x1PFAkNDSU9Pb3QezMyMgrMSUlJueQcPQ61oMysHKas2Mv7+zPYHVoGateGJhdK0jKHjvB58yBad9a6ICIiksfjbhVp2bIlb731FkePHqVSpUpERETwf//3fwB8++23lC1b1s0RioiIiCu4oiaoUaMGhmFw5MiRAuNHjhyhZs2aQN5CnCdPniQrK+sv5xw+fLjAdrvdTnJysmOOt0vPsfPEl0mU/uwUL0fUY/dNzaBeLfC70LRof/YYx3pWpnXtCDdGKiIinsbjGhfPPPMMycnJPP/88wA8+uijxMfHc8stt7Bw4ULuuusuN0coIiIiruCKmiA2NpaAgABWrlzpGEtLS2Pjxo20bt0agNatW5Obm+tYrBPyFvXcs2dPgTkpKSls3brVMWfDhg1YLBbHHG+Ua8DyUwY3rz1H2I+5zAuPxFq1YoE5IVlZ3JaTysc1slnTpSL+Ph5XnoqIiJt53K0iNWrU4KuvvnLcU/PEE09gNpv5+eefiY2NZeDAgW6OUERERFzBFTVBSEgIffr0Ydq0aZjNZiIjI5kzZw6hoaH07NkTyLtNpUuXLowZMwaLxUJYWBgJCQnExMTQqVMnAFq1akWTJk0YPHgww4cPx2azMWnSJNq3b0/Dhg2vO87i6D/H4eX9No4ZvuBTCi56gmnI6VQeLWfnqYZlaBQSiMkU6L5ARUTE43lc4+Knn36iXr16tGnTxjE2cOBABg4cyJkzZ/j666/p2rWrGyMUERERV3BVTTB06FDMZjMLFiwgIyOD2NhYJk6c6Fi/AiA+Pp74+HimTJmC3W6nTZs2jB49Gh+fvN/GTSYTs2fPZvz48YwZMwZ/f386duzIqFGjrju+4sYw4PkdWUw7E0iBUjMjizIHDzO8bggj7qrMZdZEFRERKcTjGhd9+/blgw8+IDY2ttC233//nZEjR6pxISIi4gWKoiYYMmQIQ4YMKTDm6+tLXFwccXFxl31fcHAw48ePZ/z48ZedExERwdSpU68qnpLm+Nls7lt5nPUVq18Y/H0/5X/dzut3RtK7f4NrfsqKiIh4L49oXIwcOZKTJ08CeY8NmzRpUoFvOfLt3buX8PBwV4cnIiIiLqKaoHgxDEjKhm+SM1i8+yxrfMMxLmpaBHy6mvHRAQx5vQuBAX5/sScREZHL84jGxU033cTMmTOBvEstjxw5gr+/f4E5Pj4+lC1bVmtciIiIlGCqCYqH7WdtDNlsYWNuAOmBQUAwhAcXmHPz7t/5ZERLypcNcU+QIiJSYnhE46J79+50794dgLp16zJ9+nSaNm3q5qhERETE1VQTeLZsq40hXybxVqlqGIGl4c8XUeTaqXToEFObhvFgv/ruCFFEREogj2hcXGznzp2On202G5mZmZe8RFRERERKNtUEniPbauON5dt49ZgP6c0bXdiQY4P9R6iUlkrLcDP9Gpfj3t6RbotTRERKJo9rXEBeoTJp0iR++ukncnNz8fHxoWXLlrzwwgvUr6/uvYiIiLdQTeBe2VYbEz79nTf2W7Hc1BiqXrht54YDB0mokMVdD1SndFik+4IUEZESz+MaF3v37uWRRx7B19eXu+66i/Lly3Ps2DG+/fZbevXqxZIlS6hdu7a7wxQREZEipprAfSzp2SQs28Jr2RFk128MVS5s88nJ4ZlgC1N71dAjTUVExCU8rnExbdo0brjhBj788EPKli3rGD99+jS9evVi5syZXv+oMREREW+gmsD1Tp/JYPp/N5KQeJRzD98FZcMc20x2O938MpjbPJSK/mXcGKWIiHgbj2tcbNy4kZEjRxYoUADKli3LE088weTJk90UmYiIiLiSaoKidzI1nZXr9vPZ5qP8cM7gcHA4NGkMT7d3zPHPyuLxUlmMaVKaiv6h7gtWRES8lsc1Lmw2G2XKXLqLX6ZMGdLT010ckYiIiLiDaoKikZtrZ81PySz+Zh/fJ1sxurWD9reDufB9H018rPzv5kCqBgS6IVIREZE8Hte4iIqKYuXKlbRr167QthUrVhAZGen6oERERMTlVBM4V9Kxs7z8zQGWpZpJj2wGj90KAf6FJxoGNwXY6F/Vj8dv8MfP7PpYRURELuZxjYtHH32UYcOGYTabuf/++7nhhhs4ceIEy5YtY9myZbz00kvuDlFERERcQDWBc/z0+1EGfX2IX6OioXaTS84JMXLpX97gtghfbi5l4gZ/PxdHKSIicnke17jo1q0bv/32G++99x6LFy8usK1379707t3bTZGJiIiIK6kmuH5Z1lxab8wmt2XLAuOm3FzK5WYTVSaIzmVMPF/Zh9IeVxWKiIjk8ch/okaNGkWvXr1Yv349Z86coXTp0rRq1UqXhIqIiHgZ1QTXxw7kRkc6XldPO80Ltfxpk5tMiMlOvXr13BabiIjIlfK4xsXMmTPp0aMHkZGRhYqSw4cP88477zBmzBj3BCciIiIuo5rg+gX7+/CfylmsSMlhUK0gOkbkPaFlxw67myMTERG5ch633NKsWbM4evToJbdt3bq10KWiIiIiUjKpJnCOxyMDWXRTKTpGeNz3VSIiIlfEI/4Fe/jhh9mxYwcAhmHwj3/8A5Op8CO5rFYrderUcXV4IiIi4iKqCUREROTPPKJxMWLECBYvXoxhGCxfvpxWrVoRERFRYI7ZbCYsLIwePXq4KUoREREpaqoJRERE5M88onERGxtLbGwsAMnJyQwbNkzfooiIiHgh1QQiIiLyZx7RuLjYe++95+4QRERExAOoJhARERHwwMU5RURERERERETyqXEhIiIiIiIiIh7L6xsXixcvpnPnzjRu3JiHHnqIzZs3uzskERERKcZUW4iIiDiXVzculi9fztixY7nnnnuYMWMGpUqV4rHHHuPw4cPuDk1ERESKIdUWIiIizue1jQvDMJg+fToPPvgggwcPpl27dsyePZsyZcrw7rvvujs8ERERKWZUW4iIiBQNr21cHDx4kOTkZG677TbHmJ+fH+3bt2ft2rVujExERESKI9UWIiIiRcNrGxdJSUkA1KhRo8B4tWrVOHToELm5uW6ISkRERIor1RYiIiJFw9fdAbiLxWIBICQkpMB4SEgIdrudzMxMQkNDr2hfhmEAsHv3bsxm5/eCsrKyANi+fbvT912cKA/KQT7lIY/yoBzkc1Ye7HY7cOHfNbk6zqotirquAP3dyeftefD287+YcpHH2/Pg7ed/MWfkwpl1hdc2LvKTZzKZrmj8r+Tk5ABgtVqdFN2l5X94vJ3yoBzkUx7yKA/KQT5n5SEnJ4fAwECn7MubOKu2cFVdAfq7k8/b8+Dt538x5SKPt+fB28//Ys7IhTPqCq9tXJQqVQqA9PR0ypUr5xjPyMjAbDYTHBx8xfsKCQkhOjoaPz+/q2p4iIiIeBLDMMjJySl0xYBcGWfVFqorRESkJHBmXeG1jYv8+08PHz5c4F7Uw4cPU7NmzasqFMxms6NYERERKc50pcW1c1ZtobpCRERKCmfVFV67OGdkZCSVKlVi5cqVjrGcnBy+/fZbWrdu7cbIREREpDhSbSEiIlI0vPaKC5PJxMCBAxk/fjzh4eE0bdqU999/n9TUVPr16+fu8ERERKSYUW0hIiJSNEyGly8dvmDBAhYuXEhqair16tVjxIgRxMbGujssERERKaZUW4iIiDiX1zcuRERERERERMRzee0aFyIiIiIiIiLi+dS4EBERERERERGPpcaFiIiIiIiIiHgsNS5ERERERERExGOpcSEiIiIiIiIiHkuNi2uUm5vL22+/zZ133smNN95I165def/998l/SIthGMyePZv27dvTpEkT+vfvz759+wrs48yZM4wbN44OHTrQtGlTHnroIRITEwvMSUtL48UXX6Rly5bcdNNNjB49GovF8rfxXcnxv/rqK2JiYgr9ef/9970uFwDvvfcenTt3pnHjxnTr1o0vvvjCK85/xowZl/wcxMTEcNttt11RDkpCHvL3/dJLL3HLLbfQokULnnrqKQ4fPnzFOShJuTh48CBPPfUUsbGxtGrVilGjRpGamloizv9i7777LnfffXehcavVymuvvcbNN99MbGwszz77LMePH7+qfUPJyEW+wYMH869//euq9ilXx9M/L66qLUpCHkB1xfXWFSUhF/n7vt7aoiTkQXWF6oo/u+q6wpBrMn36dKNhw4bGm2++aaxbt86YPn26Ua9ePWPevHmGYRjGjBkzjEaNGhnvvvuusXLlSuOBBx4wbrnlFuPs2bOGYRiG3W43Hn30UaNt27bG0qVLjbVr1xrPP/+8UbduXWPTpk2O4zz66KNGhw4djC+++MJYtmyZ0apVK2PQoEF/G9/fHd8wDGPq1KnG7bffbmzevLnAn5SUFK/Lxbx584z69esbc+fONdatW2e89NJLRkxMjJGYmFjiz//o0aOFPgNLly41YmJijDfffPNv919S8mAYhjFgwACjdevWxieffGKsXr3auO+++4wOHToYFovlivNQEnJx+vRp4+abbzZuu+0249NPPzVWrVpl9OjRw7j77ruN7OzsYn/++b755hujQYMGxl133VVo24svvmi0aNHCWLp0qfHll18at99+u3HPPfcYNpvtivdfUnJht9uNSZMmGdHR0cYrr7xyVecvV8fTPy+uqi1KQh5UV1x/XVEScmEYzqktinseVFeorrjYtdYValxcg9zcXCM2NtZ44403CoyPGzfOaNWqlXHu3DnjxhtvNObOnevYdubMGSM2NtZYsGCBYRiGsWXLFiM6OtpYt25dgf3efffdxrPPPmsYhmEkJiYa0dHRxq+//uqYs27dOiM6OtrYtm3bZeO7kuMbhmE89dRTxj//+c9rS8JFMRf3XJw7d85o0qSJ8dZbbxV4b+/evY0pU6aU+PP/M5vNZtx///1Gnz59DLvd/pfnX5LycPLkSSM6Otr4+OOPHXP2799vREdHG19++eUV5aGk5GL+/PlGTEyMsXfvXsecU6dOGTfeeKPx/vvvF+vzz8/BxIkTjZiYGOOmm24q9I/qwYMHjbp16xqff/65Y+zAgQNGTEyM8fXXX//lvktaLg4dOmQMGjTIaNSokdG4cWM1LoqQp39eXFVblIQ8qK4o6FrqipKSC2fUFiUhD6orVFfku566QreKXINz585x33330blz5wLjNWvW5PTp06xfv56MjAw6duzo2BYeHk6LFi1Yu3YtAGazmZ49e9K0aVPHHLPZTI0aNThy5AgAiYmJRERE0KRJE8ecli1bEhoa6tjPpWzZsuVvjw+wa9cuYmJirjELeUpCLn744Qeys7Pp2bNngfe+//77vPDCCyX+/P/s448/ZteuXbz88suYTKa/PP+SlIfs7GwAQkNDHXNKly4N5F0ud6VKQi6SkpKoXLkyUVFRjjlly5alVq1af7nv4nD+AEuWLOH//u//mDJlyiUvW16/fj0A7du3d4xFRkZSp06dv933xUpCLuLj40lJSeHDDz8kIiLiis9drp6nf15cVVuUhDyorijoWuqKkpILZ9QWJSEPqitUV+S7nrpCjYtrEB4ezssvv0z9+vULjK9Zs4aKFSs67leqVq1age1Vq1YlKSkJgIYNG/Lqq68SEBDg2G6xWPjpp5+oVasWAAcOHKB69eoF9mE2m6lSpYpjP5eSv+2vjp+enk5ycjK///47d9xxBw0aNKBbt2589913V5SDfCUhF7t27aJ8+fLs2LGD+++/nwYNGtC5c2e+/vprrzj/i2VnZzNz5kweeOAB6tSpc9n9/llJyEPlypXp0KEDc+bMYd++fZw6dYpXX32V0NBQ2rVrd0V5gJKRi4oVK5KamkpWVpZju81m49ixYyQnJxfr8wfo2LEjK1euvOx9lwcOHKBcuXIEBwdfNsYrURJy8fzzz7N06VIaNGjwt+cr18fTPy+uqi1KQh5UV1xwrXUFlIxcOKO2KAl5UF2huiLf9dQValw4yccff8y6det4/PHHsVgs+Pv74+/vX2BOSEjIXy5q8sorr2CxWOjfvz+QVwCEhIQUmvd3+7mS4+/atQvDMDhy5Agvvvgis2fPpkqVKjz55JOOruC1Km65OH36NBkZGQwdOpQePXrw1ltv0bBhQ5577jk2b958xeedr7id/8U+//xzTp06xYABA/7yHK9EccxD/sJDXbt2pU2bNqxYsYKZM2dSsWLFKzrnyyluuejSpQs2m43hw4eTnJxMSkoKr7zyCmfPniUzM/OKzzufJ50/5P2DHhgYeNnt17Pvv1PcclGnTp2r+oZUnMuTPi/urC2KWx5UV1zgzLoCimcuiqK2KG55UF2huiLf9dQValw4wWeffcbYsWO544476NOnD4ZhXPb/kEuNG4bBK6+8wmeffcaLL77o6KJdbj+GYWA25/1fZ7PZCvwx8tYt+dvj165dm3nz5rFw4UI6dOjArbfeyqxZs4iKimL27NnXlAconrmw2WycO3eOYcOG0bt3b1q3bs2UKVOIjo7mzTffLPHnf7HFixdz6623EhkZeaWnfEnFMQ/Hjx/noYceIigoiOnTp7NgwQI6dOjAM888w6+//notaQCKZy5q1apFQkICGzdu5LbbbuPWW2/FZrNx2223ERQUVKzP/0r81b6v55f44pgLcR9P+7y4q7YojnlQXXGBs+oKKJ65KIraojjmQXWF6gpn8C3yI5Rw77zzDhMnTuS2225jypQpmEwmSpUqhdVqJScnBz8/P8fc9PR0SpUqVeD9VquV4cOH8+WXX/LCCy/w6KOPOraFhoaSkpJS6JgZGRmOe+X+fJlNfHz8FR0/LCys0CVqPj4+tGnThk8//dSrcpF/2Vbbtm0d281mM61atbqiyzqL+/nnO3nyJL/++iuTJk264nO+lOKah6VLl3L27Fk++eQTKlSoAECbNm14+OGH+fe//81///tfr8kFwO23385tt93GoUOHCA8Pp2zZsjz66KOEh4cX6/Pv3r3738YdGhpKenr6Jff95xivVHHNhbiHJ35e3FFbFNc8qK7I46y6AopvLpxdWxTXPIDqCtUV10+Ni+uQkJDA3Llzue+++5gwYQK+vnnprFGjhuNSyZo1azrm//l1VlYWTz75JBs2bGDcuHE88sgjBfYfGRnJpk2bCozZ7XaSk5Pp1q0bkLcAysWqVq3K9u3b//b4v//+O9u3by+0cFRWVhZlypTxqlzUqFEDgJycnALvt9lsV9wFLc7nn++HH37Ax8enwII+V6s45+HYsWNUrFjRUVhAXne6adOmLFu2zKtykZycTGJiIj169HCM2e129uzZ85fP4y4O538lIiMjOXnyJFlZWQUudzxy5AjNmjW7on1crDjnQlzPUz8vrq4tinMeVFfkcUZdAcU7F86sLYpzHlRXqK5wiks9akT+3jvvvGNER0cbr776aqFHO1ksFqNRo0aO5+kaxoVH0cyfP98x9swzzxj169cv8Gici+U/dmbLli2Fxn777bfLxnYlx1+yZIkRHR1tbN++3TEnMzPTaNeunTFmzJgrzEKe4p6L/MdSvf322445OTk5RufOna/okW7F/fzzvfLKK8bdd9/9t+d7OcU9D/Pnzzfq169vHD16tMB7H3nkEaN79+5XkIELinsufvnll0KPvPrf//5nREdHGz/++GOxPv8/GzFixCUfWxYdHX3Jx5Z99dVXV7xvwyj+ubhYhw4d9DjUIubJnxdX1hbFPQ+qK/Jcb11hGMU/F86qLYp7HlRXqK64lKutK3TFxTU4ceKE417Fu+66iy1bthTY3rBhQ/r06cO0adMwm81ERkYyZ84cQkNDHd9CrFixghUrVnDfffdRuXLlAve5BQYGUrduXVq1akWTJk0YPHgww4cPx2azMWnSJNq3b0/Dhg0vG19ISMjfHr9Lly7MmzeP5557jueff56AgADmz59PRkYGTz31lFflombNmjzwwAMkJCRgGAa1a9fmww8/JDk5mWnTppX488+3Z8+eQt+WXKmSkIcHHniAd999l4EDB/L0008TGhrK8uXL2bRpE7NmzfKqXDRp0oT69eszevRonn/+eU6cOMFrr73GrbfeSps2bYr1+V+J6tWr06VLF8aMGYPFYiEsLIyEhARiYmLo1KnTFe+nJORCXMfTPy+uqi1KQh5UV+S5nrqipOTCGbVFSciD6grVFc5gMgyt0HW1li1bxsiRIy+7PTExkbCwMKZOnconn3xCRkYGsbGxjB492vH84hdffJFPPvnkku+vU6cO//vf/wA4deoU48eP57vvvsPf35+OHTsyatSoAs+DvhSbzfaXxwc4evQo//73vx3P/G3WrBkjRowgOjra63Jhs9l48803Wbp0KampqdStW5dhw4Zx0003ecX5A3Tt2pWmTZvy6quv/uX+LqWk5CE5OZlJkyaxbt06DMOgbt26PPvss7Rs2dLrcvHHH38wfvx4Nm7cSHBwMF27duWf//zn3y6iVRzO/2Ivvvgi27Ztc+wzX0ZGBvHx8Xz99dfY7XbatGnD6NGjC1zu+3dKSi7y3XbbbbRv356XX375ivcpV644fF5cUVuUlDyorri+ugJKTi6ut7YoKXlQXaG64s+utq5Q40JEREREREREPJYehyoiIiIiIiIiHkuNCxERERERERHxWGpciIiIiIiIiIjHUuNCRERERERERDyWGhciIiIiIiIi4rHUuBCRYksPRRIRERFnUm0h4pnUuBARt4uJibniZzjn+7tnWYuIiIj3Um0hUrKocSEixdLMmTNJSUlxdxgiIiJSQqi2EPFcalyIiIiIiIiIiMdS40JEXOr999+nS5cuNGrUiHvvvZdffvmlwHaLxcLkyZMdc5o0aUL37t359NNPHXNiYmJITk7mhx9+ICYmhg0bNgCQkZHBpEmT6NChAw0bNuT2229n7ty55ObmuvQcRURExHVUW4iUfL7uDkBEvMfMmTOZMWMGDz74ICNHjmTXrl08+eSTBeY89dRT7N69m+eee46aNWty8uRJFixYwIgRI6hbty4xMTH897//5Z///CeVK1dm+PDhxMTEkJOTw4ABAxz7rFu3Lr/88gvTpk0jKSmJ+Ph4N521iIiIFBXVFiLeQY0LEXEJi8XCvHnz6NKlC+PHjwegXbt2lC9fnhdffBGAlJQUDMNg3Lhx3HnnnY73RkZG0qNHDxITE4mJiaF58+b4+/tTqlQpmjdvDuQtqLV582amTp3qeG+7du0oW7Ys8fHxPPLIIzRu3NjFZy0iIiJFRbWFiPfQrSIi4hK//vor2dnZ3HHHHQXG7777bszmvP8UlS9fnvfff58777yT06dPs3nzZj799FM++OADAKxW62X3/+OPP+Lr60uHDh2w2WyOP126dAHg+++/L6IzExEREXdQbSHiPXTFhYi4RGpqKgDlypUrMO7n50fZsmUdr1euXMnUqVPZs2cPQUFBREVFUadOnb/d/+nTp7HZbDRp0uSS248fP34d0YuIiIinUW0h4j3UuBARl4iIiAAo9Jgxu91OWloaAJs2beLZZ5/lrrvuYtasWVSvXh2TycSePXv45JNP/nL/YWFhhIeHM3/+/EtuL1OmjBPOQkRERDyFagsR76FbRUTEJWJjYwkODi6wgjfA6tWrycnJAfKKi9zcXJ588klq1KiByWRyzIG8QiRf/iWg+dq0aUNaWhomk4lGjRo5/thsNiZPnsy+ffuK8vRERETExVRbiHgPXXEhIi4RFBTECy+8wPjx43nhhRfo1q0bhw4d4s0338TPzw+AG2+8EYDXXnuNvn37ArBq1SqWLFkCQGZmpmN/YWFh7N27lx9//JH69etz3333sWjRIp544gkGDhxIdHQ0SUlJzJgxg8DAQC2eJSIiUsKothDxHibDMAx3ByEi3mP58uXMnz+fpKQkqlSpwvPPP8+ECRNo3749//rXv1i2bBlvvfUWR44coVSpUtSpU4dBgwYxceJEQkJC+PDDDwH48ssvmTBhAmlpacTHx3P33XdjsViYMWMG33zzDSkpKZQtW5abb76ZZ599lkqVKrn5zEVERKQoqLYQKfnUuBARERERERERj6U1LkRERERERETEY6lxISIiIiIiIiIeS40LEREREREREfFYalyIiIiIiIiIiMdS40JEREREREREPJYaFyIiIiIiIiLisdS4EBERERERERGPpcaFiIiIiIiIiHis/wcDUOt81lv9vgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 1080x720 with 4 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Plotting settings\n",
+    "sns.set_style(\"whitegrid\")\n",
+    "plt.style.use('seaborn-poster')\n",
+    "slides_palette = [\"#00287f\", \"#00c5ff\"]\n",
+    "sns.set_palette(slides_palette)\n",
+    "f, axes = plt.subplots(2, 2, figsize=(15,10))\n",
+    "\n",
+    "\n",
+    "g1 = sns.lineplot(data=pivot_lebanese_data, x='date', y='cases', hue='value_type', ax=axes[0][0]);\n",
+    "g1.set_title('LEBANON', weight='bold');\n",
+    "g1.set_xlabel('date');\n",
+    "g1.set_ylabel('total cases per million in 2 weeks');\n",
+    "g1.set_ylim(0,16000)\n",
+    "g1.legend().set_title('');\n",
+    "g1.legend(loc='upper left');\n",
+    "\n",
+    "g2 = sns.lineplot(data=pivot_german_data, x='date', y='cases', hue='value_type', ax=axes[0][1]);\n",
+    "g2.set_title('GERMANY', weight='bold');\n",
+    "g2.set_xlabel('date');\n",
+    "g2.set_ylabel('total cases per million in 2 weeks');\n",
+    "g2.set_ylim(0,16000)\n",
+    "g2.legend().set_title('');\n",
+    "g2.legend(loc='upper left');\n",
+    "\n",
+    "g3 = sns.lineplot(data=pivot_taiwanese_data, x='date', y='cases', hue='value_type', ax=axes[1][0]);\n",
+    "g3.legend().set_title('');\n",
+    "g3.set_title('TAIWAN', weight='bold');\n",
+    "g3.set_xlabel('date');\n",
+    "g3.set_ylabel('total cases per million in 2 weeks');\n",
+    "g3.set_ylim(0,30)\n",
+    "g3.legend().set_title('');\n",
+    "g3.legend(loc='upper left');\n",
+    "\n",
+    "g4 = sns.lineplot(data=pivot_mexican_data, x='date', y='cases', hue='value_type', ax=axes[1][1]);\n",
+    "g4.set_title('MEXICO', weight='bold');\n",
+    "g4.set_xlabel('date');\n",
+    "g4.set_ylabel('total cases per million in 2 weeks');\n",
+    "g4.set_ylim(0,8000)\n",
+    "g4.legend().set_title('');\n",
+    "g4.legend(loc='upper left');\n",
+    "\n",
+    "plt.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# plot the residuals\n",
+    "viz = residuals_plot(RandomForestRegressor(criterion='mae'), X_train, y_train, X_test, y_test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# make feature dependence plots\n",
+    "features = [\"hdi\", \"median_age\", \"smoothed_pct_wear_mask_all_time_weighted\", \"smoothed_pct_wear_mask_most_time_weighted\",\n",
+    "            \"cur_mask_recommended\", \"cur_mask_not_required\", \"cur_mask_not_required_recommended\", \n",
+    "            \"cur_mask_not_required_universal\", \"cur_mask_required_part_country\", \"cur_mask_everywhere_in_public\",\n",
+    "            \"cur_mask_public_indoors\", \"cur_mask_public_transport\",\"total_cases_per_million\",\"previous_7days\"]\n",
+    "\n",
+    "plot_partial_dependence(wrapped_model, X_train, features,\n",
+    "                        n_jobs=3, grid_resolution=20)\n",
+    "fig = plt.gcf()\n",
+    "fig.suptitle('Partial dependence of covid-19 cases on features.')\n",
+    "fig.subplots_adjust(hspace=0.5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Answering research questions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create a pivot table with the overall percentages of wearing mask all time per country\n",
+    "pivot_mask_all_time = df_time.groupby(['iso_code'])[['smoothed_pct_wear_mask_all_time_weighted']].mean()\n",
+    "pivot_mask_all_time = pivot_mask_all_time.stack().reset_index()\n",
+    "pivot_mask_all_time.drop('level_1', axis=1, inplace=True)\n",
+    "pivot_mask_all_time = pivot_mask_all_time.rename(columns={0: \"mask_all_time\"})\n",
+    "\n",
+    "# split dataset into countries with more and those with less mask wearing\n",
+    "masks_all_more = pivot_mask_all_time[pivot_mask_all_time.mask_all_time >= 50]\n",
+    "masks_all_less = pivot_mask_all_time[pivot_mask_all_time.mask_all_time < 50]\n",
+    "print('all',masks_all_more.iso_code.nunique())\n",
+    "print('not all',masks_all_less.iso_code.nunique())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# list of social distancing measures that are not well adhered to when the values are high\n",
+    "columns_soc_dist_bad = [\"smoothed_pct_worked_outside_home_weighted\", \"smoothed_pct_grocery_outside_home_weighted\", \"smoothed_pct_ate_outside_home_weighted\", \n",
+    "                             \"smoothed_pct_attended_public_event_weighted\", \"smoothed_pct_used_public_transit_weighted\", \n",
+    "                             \"smoothed_pct_direct_contact_with_non_hh_weighted\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create a pivot table with the overall percentages per measure per country\n",
+    "pivot_soc_dist = df_time.groupby(['iso_code'])[columns_soc_dist_bad].mean()\n",
+    "pivot_soc_dist = pivot_soc_dist.stack().reset_index()\n",
+    "pivot_soc_dist = pivot_soc_dist.rename(columns={0: \"percentage\"})\n",
+    "\n",
+    "# create a pivot table with the overall percentages over all measures per country\n",
+    "pivot_soc_dist_overall = pivot_soc_dist.groupby(['iso_code'])[['percentage']].mean()\n",
+    "pivot_soc_dist_overall = pivot_soc_dist_overall.stack().reset_index()\n",
+    "pivot_soc_dist_overall.drop('level_1', axis=1, inplace=True)\n",
+    "pivot_soc_dist_overall = pivot_soc_dist_overall.rename(columns={0: \"percentage\"})\n",
+    "\n",
+    "# split dataset into countries that adhere more and less to social distancing measures\n",
+    "soc_dist_more = pivot_soc_dist_overall[pivot_soc_dist_overall.percentage < 34]\n",
+    "soc_dist_less = pivot_soc_dist_overall[pivot_soc_dist_overall.percentage >= 34]\n",
+    "print('most',soc_dist_more.iso_code.nunique())\n",
+    "print('not_most',soc_dist_less.iso_code.nunique())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create a list of isocodes of countries that adhere well to mask wearing and social distancing (good_guys) and of those who do not (bad_guys)\n",
+    "good_guys = list(set(masks_all_more['iso_code']).intersection(set(soc_dist_more['iso_code'])))\n",
+    "bad_boys = list(set(masks_all_less['iso_code']).intersection(set(soc_dist_less['iso_code'])))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# select rows from the dataframe based on iso codes of adhering and not adhering countries\n",
+    "adhering = df_time[df_time[\"iso_code\"].isin(good_guys)]\n",
+    "not_adhering = df_time[df_time[\"iso_code\"].isin(bad_boys)]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Adhering model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# drop iso code and date columns\n",
+    "df_adhering = adhering.drop([\"iso_code\",\"date\"], axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define X and y\n",
+    "adh_X = df_adhering.drop(\"next_14days\", axis=1)\n",
+    "adh_y = df_adhering[\"next_14days\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# divide the data into train and test data\n",
+    "adh_X_train, adh_X_test, adh_y_train, adh_y_test = train_test_split(adh_X, adh_y, test_size=0.2, random_state=42)\n",
+    "print(adh_X_train.shape, adh_X_test.shape, adh_y_train.shape, adh_y_test.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = RandomForestRegressor(criterion='mae')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define the target transform wrapper \n",
+    "adh_wrapped_model = TransformedTargetRegressor(regressor=model,transformer=MinMaxScaler()) \n",
+    "# use the target transform wrapper \n",
+    "adh_wrapped_model.fit(adh_X_train, adh_y_train) \n",
+    "adh_yhat = adh_wrapped_model.predict(adh_X_test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# evaluate the model\n",
+    "print('mae:',metrics.mean_absolute_error(adh_y_test, adh_yhat))\n",
+    "print('mape:',mean_absolute_percentage_error(adh_y_test, adh_yhat))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# plot the residuals\n",
+    "viz = residuals_plot(RandomForestRegressor(criterion='mae'), adh_X_train, adh_y_train, adh_X_test, adh_y_test)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Not adhering model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# drop iso_code and date columns\n",
+    "df_not_adhering = not_adhering.drop([\"iso_code\",\"date\"], axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define X and y\n",
+    "not_adh_X = df_not_adhering.drop(\"next_14days\", axis=1)\n",
+    "not_adh_y = df_not_adhering[\"next_14days\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# divide the data into train and test data\n",
+    "not_adh_X_train, not_adh_X_test, not_adh_y_train, not_adh_y_test = train_test_split(not_adh_X, not_adh_y, test_size=0.2, random_state=42)\n",
+    "print(not_adh_X_train.shape, not_adh_X_test.shape, not_adh_y_train.shape, not_adh_y_test.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = RandomForestRegressor(criterion='mae')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define the target transform wrapper \n",
+    "not_adh_wrapped_model = TransformedTargetRegressor(regressor=model,transformer=MinMaxScaler()) \n",
+    "# use the target transform wrapper \n",
+    "not_adh_wrapped_model.fit(not_adh_X_train, not_adh_y_train) \n",
+    "not_adh_yhat = not_adh_wrapped_model.predict(not_adh_X_test)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# evaluate the model\n",
+    "print('mae:',metrics.mean_absolute_error(not_adh_y_test, not_adh_yhat))\n",
+    "print('mape:',mean_absolute_percentage_error(not_adh_y_test, not_adh_yhat))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# plot the residuals\n",
+    "viz = residuals_plot(RandomForestRegressor(criterion='mae'), not_adh_X_train, not_adh_y_train, not_adh_X_test, not_adh_y_test)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Testing the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_prediction(iso_code,date):\n",
+    "    pred = df_time.loc[(df_time[\"iso_code\"]==iso_code) & (df_time[\"date\"]==date)]\n",
+    "    pred = pred[columns_interest]\n",
+    "    true_value = pred[\"next_14days\"].values\n",
+    "    pred.drop([\"iso_code\",\"date\",\"next_14days\"], axis=1, inplace=True)\n",
+    "    pred_overall = wrapped_model.predict(pred)\n",
+    "    pred_adh = adh_wrapped_model.predict(pred)\n",
+    "    pred_not_adh = not_adh_wrapped_model.predict(pred)\n",
+    "    print('true number of cases:',str(true_value)[1:-1])\n",
+    "    print('predicted number of cases:',str(pred_overall)[1:-1])\n",
+    "    print('predicted number of cases if inhabitants adhered to mask wearing and social distancing:',str(pred_adh)[1:-1])\n",
+    "    print('predicted number of cases if inhabitants have not adhered to mask wearing and social distancing:',str(pred_not_adh)[1:-1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "included = good_guys+bad_boys\n",
+    "excluded = list(set(df_time.iso_code).symmetric_difference(included))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "impossible = ['BHS','UGA','SSD','BHR','CAF']\n",
+    "for i in impossible:\n",
+    "    if i in excluded:\n",
+    "        excluded.remove(i)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(excluded)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in excluded:\n",
+    "    print(i)\n",
+    "    make_prediction(i,\"2020-07-16\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Second approach\n",
+    "Filling out custom numbers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def predict_scenario(iso_code,date,pc_mask_wearing,pc_social_distancing):\n",
+    "    scenario = df_time.loc[(df_time[\"iso_code\"]==iso_code) & (df_time[\"date\"]==date)]\n",
+    "    scenario = scenario[columns_interest]\n",
+    "    \n",
+    "    true_value = scenario[\"next_14days\"].values\n",
+    "    \n",
+    "    scenario.drop([\"iso_code\",\"date\",\"next_14days\"], axis=1, inplace=True)\n",
+    "    \n",
+    "    scenario_adhering = scenario.copy()\n",
+    "    scenario_adhering[[\"smoothed_pct_worked_outside_home_weighted\", \"smoothed_pct_grocery_outside_home_weighted\",\n",
+    "                 \"smoothed_pct_ate_outside_home_weighted\", \"smoothed_pct_attended_public_event_weighted\",\n",
+    "                 \"smoothed_pct_used_public_transit_weighted\", \"smoothed_pct_direct_contact_with_non_hh_weighted\"]] = 100-pc_social_distancing\n",
+    "    scenario_adhering[\"smoothed_pct_wear_mask_all_time_weighted\"] = pc_mask_wearing\n",
+    "    \n",
+    "    scenario_not_adhering = scenario.copy()\n",
+    "    scenario_not_adhering[[\"smoothed_pct_worked_outside_home_weighted\", \"smoothed_pct_grocery_outside_home_weighted\",\n",
+    "                 \"smoothed_pct_ate_outside_home_weighted\", \"smoothed_pct_attended_public_event_weighted\",\n",
+    "                 \"smoothed_pct_used_public_transit_weighted\", \"smoothed_pct_direct_contact_with_non_hh_weighted\"]] = pc_social_distancing\n",
+    "    scenario_not_adhering[\"smoothed_pct_wear_mask_all_time_weighted\"] = 100-pc_mask_wearing\n",
+    "    \n",
+    "    pred_scenario = wrapped_model.predict(scenario)\n",
+    "    pred_scenario_adhering = wrapped_model.predict(scenario_adhering)\n",
+    "    pred_scenario_not_adhering = wrapped_model.predict(scenario_not_adhering)\n",
+    "    \n",
+    "    #print('true number of cases:',str(true_value)[1:-1]))\n",
+    "    #print('predicted number of cases:',str(pred_scenario)[1:-1])\n",
+    "    #print('predicted number of cases if inhabitants adhered to mask wearing and social distancing:',str(pred_scenario_adhering)[1:-1])\n",
+    "    #print('predicted number of cases if inhabitants have not adhered to mask wearing and social distancing:',str(pred_scenario_not_adhering)[1:-1])\n",
+    "    \n",
+    "    return str(true_value)[1:-1],str(pred_scenario)[1:-1],str(pred_scenario_adhering)[1:-1],str(pred_scenario_not_adhering)[1:-1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('8893.085', '8819.95373', '8781.35048', '8250.46506')"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "predict_scenario(\"GBR\",\"2020-09-28\",80,80)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in excluded:\n",
+    "    print(i)\n",
+    "    predict_scenario(i,\"2020-07-16\",80,80)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### South-Africa"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dates = []\n",
+    "true_values = [] \n",
+    "predicted_values = []\n",
+    "predicted_values_adhering = []\n",
+    "predicted_values_not_adhering = []\n",
+    "\n",
+    "for i in df_time.date.unique():\n",
+    "    i = str(i).split('T')[0]\n",
+    "    dates.append(i)\n",
+    "    true,prediction,prediction_adh,prediction_not_adh = predict_scenario('ZAF', i, 80, 80)\n",
+    "    true_values.append(true)\n",
+    "    predicted_values.append(prediction)\n",
+    "    predicted_values_adhering.append(prediction_adh)\n",
+    "    predicted_values_not_adhering.append(prediction_not_adh)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sth_african_data = pd.DataFrame([], columns=['date','true_value','predicted_value','predicted_value_adhering',\n",
+    "                                             'predicted_value_not_adhering'])\n",
+    "sth_african_data['date'] = dates\n",
+    "sth_african_data['true_value'] = true_values\n",
+    "sth_african_data['predicted_value'] = predicted_values\n",
+    "sth_african_data['predicted_value_adhering'] = predicted_values_adhering\n",
+    "sth_african_data['predicted_value_not_adhering'] = predicted_values_not_adhering"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sth_african_data['date'] = pd.to_datetime(sth_african_data.date, errors='coerce')\n",
+    "sth_african_data['true_value'] = pd.to_numeric(sth_african_data.true_value, errors='coerce')\n",
+    "sth_african_data['predicted_value'] = pd.to_numeric(sth_african_data.predicted_value, errors='coerce')\n",
+    "sth_african_data['predicted_value_adhering'] = pd.to_numeric(sth_african_data.predicted_value_adhering, errors='coerce')\n",
+    "sth_african_data['predicted_value_not_adhering'] = pd.to_numeric(sth_african_data.predicted_value_not_adhering, errors='coerce')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pivot_sth_african_data = sth_african_data.groupby(['date'])[['true_value','predicted_value','predicted_value_adhering',\n",
+    "                                                            'predicted_value_not_adhering']].mean()\n",
+    "pivot_sth_african_data = pivot_sth_african_data.stack().reset_index()\n",
+    "pivot_sth_african_data = pivot_sth_african_data.rename(columns={\"level_1\":\"value_type\",0: \"cases\"})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sth_african_mask = (pivot_sth_african_data.date < pd.to_datetime('2020-11-01'))\n",
+    "pivot_sth_african_data = pivot_sth_african_data.loc[sth_african_mask]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAyMAAAItCAYAAAAqrqUBAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8vihELAAAACXBIWXMAAAsTAAALEwEAmpwYAAD1wklEQVR4nOzdd1gU1/rA8e8uLEtZEAQRAypiwQJiV+y9m+T6S4wpJrm2RKOJxp5ce2ILdg1qYozRxHIT9RprFLsC9hiNXVDBRu91d39/rGxYAQWkmbyf59nH2ZkzZ87MQZ2X0xR6vV6PEEIIIYQQQpQwZWkXQAghhBBCCPHPJMGIEEIIIYQQolRIMCKEEEIIIYQoFRKMCCGEEEIIIUqFBCNCCCGEEEKIUiHBiBBCCCGEEKJUmJd2AYQQQhReeno669atY8+ePYSGhpKcnIy9vT1eXl689dZbtGvXLsc5ycnJbNiwgf379xMSEkJiYiLlypWjbt269OnTh969e6NUmv6uasCAAZw8eRJra2vOnTuXI8/Vq1czb948AH744QeaN29Ox44dCQ8Pz9d9XL16leDgYN59910Axo8fz6BBg3Kk8/T0BKB9+/asXLkyX3ln2bFjB2PGjAHA1taWY8eOYWlpmSNd9nI8zbZt26hTpw5Lly5l2bJlOY4rFArUajXOzs40b96ckSNHUrFiRePxZz3Tw4cPs3nzZn7//XdiY2OxsbGhXr16vPbaa/Ts2fOpZRs0aBDHjh0D4I033mDGjBnPvB8hhCgNEowIIcQLKjU1lffee4/z58+b7I+MjOTQoUMcOnSIkSNHMmLECOOxW7du8cEHH3Dnzp0c5xw5coQjR46wYcMGli9fTvny5UviNkrML7/8YtxOSEhgz549vPrqq8V2Pb1eT2pqKnfu3OHOnTucOHGCLVu2YG9v/9Tz0tPT+eyzz/j1119N9sfGxnL8+HGOHz/Ob7/9xoIFC3IEjQD379/nxIkTxu87duxg4sSJWFtbF8l9CSFEUZJgRAghXlAbNmwwBiJvvPEG/fr1Q6PRcOnSJWbOnElMTAzLly+nT58+VK1alfj4eAYPHmxsrejZsydvvfUWLi4u3L17l++++46jR49y9uxZhg8fzrp161CpVIUu36ZNm9Bqtcbvn3zyCefPn8fKyoo9e/Y8170X1L179wgKCjLZt3nz5mcGI8OGDaN///65HnN0dMyxb9WqVcbWG51OR1RUFHPmzOH06dOEh4ezYcMGhg0b9tRrzpkzxxiINGvWjOHDh1OpUiX+/PNP/Pz8CA8PZ/fu3dSuXZsPP/wwx/lbtmxBp9MZvyclJbFz505ef/31p15XCCFKgwQjQgjxggoODgZAqVQyefJkY+Dg7u5OfHw806ZNQ6fTERwcTNWqVVm5cqUxEHnnnXeYPHmyMa/KlSvTokULPv74Y/bt28e5c+fYtm3bc73AVqhQweS7hYUFYOi+5OLiUuh8CyP7C3rVqlW5ffs2Z86c4ebNm1SvXj3P82xtbQtU1vLly5ukf+mll5gwYYLxOV64cOGp59+8eZOffvoJAB8fH7777juTeq1Xrx69evUiIyODLVu28MEHH6BQKIzn6/V6tm7darx2REQEGRkZ/PzzzxKMCCHKJBnALoQQL6isl3udTse4ceO4evWq8djrr79OYGAggYGBvPLKKwDs3LkTAEtLS0aNGpUjP6VSybhx44zfs3drepE9+YI+duxY47Gff/652K9vZmZm3Laysnpq2u3bt6PX6wHDuI8nW6aqVq3KwoUL+eWXX9i9e7dJIAJw8uRJ7t69C8Crr75KmzZtADh//jzXrl177nsRQoiiJsGIEEK8oHr16mXc3r17Ny+//DIdOnRg0qRJ7N+/HxsbG8qXL49arebevXvcv38fAG9vb2xtbXPNs2rVqrz00ksAXLx40aSbVUlKSEjgwYMHOT6FERQURFhYGGDomta+fXvs7OwAwyD09PT0Iit3dunp6dy9e5fFixcb97Vo0eKp52Qf/9OgQYNc03Tp0gUvLy+TICdL9gCyd+/e9OnTx/j9v//9bz5LLoQQJUe6aQkhxAuqW7du/Pvf/2bNmjXGfffu3WPLli1s2bIFR0dHpk+fTpcuXYiKijKmyT6jU26cnZ25d+8eGRkZxMXFlcpAdn9/f/z9/Yskrydf0C0sLOjSpQu//PIL0dHRBAQE0KNHj1zPnTdvnnGWsOyyZgx70muvvZZnOdq0acP//d//PbWskZGRxu2CPvfExER+++03AGrXrk316tVxdXXF2tqa5ORktm/fzrhx44wtakIIURZIy4gQQrzAJk6cyMaNG/nXv/6Fg4ODybGoqCg++eQTTp8+bdLCkdUNKC/ZBz8/K21ucpvhqThFR0fnaEFJSUkBDC/o+/btA8DDw4M6deoAmLQYFHdXrVatWjF37lxWrVqVa2tGdgWppyft2rXLeN9ZrWaWlpZ06dIFMMzGlRWsCCFEWSEtI0II8YJr2LAhDRs2RK/Xc/XqVU6cOMHmzZsJCQlBq9Xy/fffM2HCBGP6e/fuPTW/rO5c5ubmlCtXDsA4diGvF+TsL9Hm5s//X8uz1hnJ7pNPPuHkyZMm+2bPnk3fvn3ZsWMHqampANSsWZMjR44AhvuwsrIiJSWF48ePExYWhpubW46885pNK69Wi1WrVuHm5sZvv/3GkiVL0Ol0hIaGUrdu3XwFaeXLlyckJAQwBJOVKlXKkUan0+WaV/YWIDs7O+O9Zs9j8+bN9O7d+5nlEEKIkiLBiBBCvICio6NZtGgRjx49okGDBnz44YcoFApq165N7dq1efPNN2nfvj2xsbHcunWLypUr4+joSFRUFBcvXiQ6OjrXF+qrV68SEREBgJeXlzGwyBpjkZqaSmZmZo6AIzk52bhtY2NTXLddYNlf0Pfu3cvevXtzpNHr9fz888+5DuovzGxa1atXN07fu2jRIsLDwxk4cCBbt27NMcPYk+rXr8+ZM2cAw/iR3IKRd955B5VKRZcuXejfvz/m5ubcvHnTZLzJ1KlTc83/5MmT3L59m6pVq+b7noQQojhJNy0hhHgBaTQafv31Vw4ePMj69etJTEw0Oa5UKo2tFVmtG1mzamVkZOQ6DiIzM5O5c+cav/ft29e4XblyZcDw4p59Qb0sly5dMl43awB8SVm3bh1Xr141+fTt25cbN248cyrdLFu2bCnywfpDhw41DkKPiIjIM0DI7uWXXzZuf//992RmZpocP336NGfOnCEoKIiffvrJGBTmd+azrMBLCCHKCglGhBDiBWRhYWEMLiIiIhgyZAjHjx/nzp07BAcHM2zYMBISEgDDQHeADz74AFdXVwC2bt3K8OHDCQ4O5u7duxw7dox///vfHD9+HDD8hv5f//qX8Xpdu3Y1TiM7ceJEtm7dyq1bt7h8+TKzZ882dglq1qwZGo2mZB7CM2R/Qf/yyy9zBCxXr141zm718OFD4z0UFTMzM2bNmoVarQYgICDgmWM26tataxwEf/78eYYMGcLJkycJCQnhl19+YeTIkca0I0aMAAxB5Pbt2wHD1MFnzpzJcZ8HDhwwdu3aunVrjiBHCCFKi3TTEkKIF9SYMWP4/fff+fPPPzl79iwDBw7MkcbX15e33noLAHt7e7755huGDRvG7du3CQgIICAgIMc5Pj4+fP311yazLnl7e/Phhx/i7+9PVFQUEydOzHGeg4ODyUKKpSn7C7q1tTXdu3fPNd0bb7xhXJn9v//9Lx06dCjSclSvXp0RI0Ywf/58wBAUtWrV6qld2aZMmUJCQgJ79+7lxIkTubZEDR48mJ49ewJw+PBhY9e6bt265RoMurq60rp1a44cOUJERASHDh2ic+fORXGLQgjxXKRlRAghXlC2trZs3LiRCRMm0KBBAzQaDebm5jg4ONCsWTOmTp3K6tWrTYKK6tWrs337dj7//HOaNm1KuXLljOe0bt2aOXPmsGHDBpycnHJcb9SoUfj7+9O+fXsqVKiASqXC0tISd3d3BgwYwP/+9z9q1KhRko8gT4cOHTJOk5vXCzoY1uxwdHQEDC/1jx49KvKyDBo0iPr16wPw4MEDli5d+tT0arWaJUuWsGTJEtq0aYO9vT3m5uY4OjrSsWNHvvvuO5PFKbds2WLczt617klvvPGGcXvz5s2FvR0hhChSCn1h5m0sIgEBAYwdO5Zz586Z7N+5cycrVqwgNDSUSpUqMWDAAAYMGGA8np6ejp+fHzt37iQ5OZk2bdrw+eefm8ydHxcXx+zZszl48CA6nY6uXbsyadIkk/+Q7t+/zxdffEFQUBBqtZpXX32VUaNGyRzsQgghhBBClIBS66Z19uxZk9/sZNm1axdjxozh3//+N5999hlBQUF88cUXaDQaY//lqVOncuDAASZMmIC1tTULFixg6NChbNmyxTiH+8iRIwkLC2PatGmkpqYyb948IiMjWblyJWAIaAYOHIilpSXz5s3j/v37+Pn5kZqaypQpU0ruQQghhBBCCPEPVeLBSHp6OmvXrmXx4sVYW1uTkZFhPKbX6/nqq6946623jHPi+/r6EhYWxvHjx/nXv/7FnTt32LZtG/Pnzzf2l61duzbdu3cnICCArl27EhQURHBwMJs3b8bHxwcAFxcX3n//fS5dukS9evX49ddfuXPnDgEBAcZpG9VqNdOmTWP48OG5dlEQQgghhBBCFJ0SHzNy5MgRVq1axfjx43nnnXdMjl28eJF79+7Rr18/k/3z58/Hz88PwDjQsH379sbj7u7u1KxZk6NHjwIQGBiIo6OjMRABaN68ORqNxpjmxIkT1K1b12T++M6dO5OZmUlgYGDR3bAQQgghhBAiVyXeMuLt7U1AQAB2dnY5BvFdvXoVMKzk+84773D+/HkcHR0ZOnQob7/9NgAhISE4OTlhbW1tcq6bmxuhoaHGNFWqVDE5rlQqcXV1NaYJDQ3F3d3dJI2DgwMajcaYJr90Oh1JSUmoVCrj1JdCCCGEEEL80+n1ejIyMrCxsTFOMZ5diQcj2QeZPyk6OhozMzOGDRvGW2+9xUcffcT+/fuZMWMGDg4O9OzZk6SkpFynRLSxseHBgwcAT02TtTBYYmLiM9PkV1JSEteuXSvQOUIIIYQQQvxT1KpVC1tb2xz7y9Q6I5mZmWi1Wvr168eHH34I/DVmZNmyZfTs2RO9Xp9r60P2/Xq9PtfI68n9eeWT27lPo1KpAMNDLmszcd24cQOgzEy3KZ5N6qzskzp68UidvXikzso+qaMXT2nUWXp6OteuXTO+Lz+pTAUjWV2v2rZta7K/ZcuWzJ07l/T0dDQaDUlJSTnOTU5ONkZbGo3GuADUk2mypvZ9Wj4FXT04K6ixsLAwrrRbVmQFVmWtXCJvUmdln9TRi0fq7MUjdVb2SR29eEqzzvIaylCmFj2sWrUqYIigssvMzDS2WLi7uxMZGUlqaqpJmrCwMKpVqwYYBrTfvXvX5LhOpyM8PNwkTVhYmEmamJgYEhMTjWmEEEIIIYQQxadMBSNNmzZFrVazZ88ek/2HDh3C29sbc3NzfH190Wq1HDhwwHg8NDSU69ev4+vrCxi6dkVERHDhwgVjmuDgYBITE41pWrRowcWLF43jTAD279+PSqWiadOmxXmbQgghhBBCCMpYNy2NRsMHH3zAsmXL0Gg0NGvWjF27dnHq1ClWrVoFQJUqVejevTuTJ08mMTEROzs7FixYgKenJ507dwYMgYaPjw8jRoxg/PjxZGZmMnfuXNq3b4+XlxcAvXv3xt/fn8GDB/PJJ5/w6NEjvvrqK/r160eFChVK7RkIIYQQQgjxT1GmghGAjz76CFtbW9avX8/q1atxd3dn6dKlJuNIZs+ezezZs/Hz80On09GyZUs+//xz4+rrCoUCf39/Zs6cyeTJk7GwsKBTp0589tlnxjysrKxYs2YNM2bMYOzYsdja2vLmm2/y6aeflvg9CyGEEEII8U+k0Ov1+tIuxIsuLS2Nixcv4uXlVeYGcV2+fBmAOnXqlHJJRH5JnZV9UkcvHqmzF4/UWdkndfTiKY06e9Z7cpkaMyKEEEIIIYT455BgRAghhBBCCFEqJBgRQgghhBBClAoJRoQQQgghhBClQoIRIYQQQgghRKmQYEQIIYQQQghRKiQYEUIIIYQQQpQKCUZEockSNUIIIYQQ4nlIMCIKZf/+/UydOrW0i1FktmzZgqenJ9HR0aVdFCGEEEKIfwzz0i6AeDGtXbsWa2vr0i6GEEIIIYR4gUnLiBBCCCGEEKJUSDAiCmzAgAGcPHmSQ4cO4enpycSJE+nbty+zZs2iSZMm9O/fn7CwMDw9PdmzZ4/Jua+88goTJ040fk9OTmbmzJm0bNmS+vXrM2DAAP788898lyU5OZmGDRuycuVKk/3Xr1/H09OTwMBAAC5cuMCQIUNo0qQJXl5edOvWjY0bNz71Hj/44AOTfd9//z2enp4m+3bs2EGfPn3w9vamc+fOrFu3Lt9lF0IIIYT4p5NuWqVo066LTFl6kISktGK7RmZmJgDm5jtzPW5ro2bGyA680dMr33lOnTqVcePGYWlpyYQJEwgICODXX39FrVazdOlS0tLydz96vZ5hw4Zx9epVPv30UypUqMD69esZMGAAW7dupUqVKs/Mw9ramo4dO7Jnzx6T4GHXrl1UqFCB5s2bc+/ePd59913atWvH4sWLyczMZMOGDUydOpUGDRpQu3btfN97dlu3bmXixIm8/fbbTJgwgfPnzzN79mzS0tIYPHhwofIUQgghhPgnkWCkFH313XGuhUaVahnuRyTit+ZEgYKRGjVqoNFosLa2pkGDBhw9epTMzEw+++wzvL29AQgLC3tmPseOHSMoKIg1a9bQsmVLANq0aUOvXr3w9/dn9uzZ+SpP7969+fDDD7lz544xgNmzZw89evRAqVRy/fp1GjRogJ+fHyqVCgAfHx+aN2/O6dOnCxWM6HQ6FixYQJ8+fZgyZQoArVu3RqFQ8PXXX/PWW2/JmBohhBBCiGeQYKQUjRvYqgRbRnKvalsbNeMGtiySa1WvXr1A6YODg7GysqJp06bGcoLhpf7AgQP5zqd169bY29uzZ88ehg4dypUrV7h16xZz584FoF27drRr1460tDSuXLlCaGgof/zxBwDp6ekFKnOWkJAQHj16RPv27U3K3rZtW5YsWcKFCxdo0aJFofIWQgghhPinkGCkFL3R06tALRKFcfnyZQDq1KlTrNextrYucEtAbGwsKSkpeHnlfAZZLRj5oVKp6NatmzEY2b17N5UrV6Z+/foAaLVa5syZw6ZNm8jIyKBKlSo0adIEKPxaKbGxsQCMGTOGMWPG5DgeERFRqHyFEEIIIf5JJBgRxUKhUACG7kzZJScnG7dtbW1xdHTMMfi8MHr37s2mTZsICwtjz5499OrVy3jM39+fzZs3M3fuXNq1a4e1tTUpKSn8/PPPT83zWWUHmDJlijHoyc7Nze15bkcIIYQQ4h9BZtMShaJUPv1HR6PRAPDo0SPjvocPH5qMJWncuDHR0dFYW1vj7e1t/Pz6669s3769QOVp2rQpLi4ufPvtt4SGhtKnTx/jsfPnz+Pl5UWPHj2MrTdHjx4F8m4Z0Wg0JmUHOHPmjHHbw8MDe3t7Hj58aFL22NhYFi9eTGJiYoHKL4QQQgjxTyQtI6JQ7OzsuHz5MsHBwaSmpuY4Xq5cOXx8fPjuu++oVKkSZmZmLFu2DDs7O2OaDh064O3tzdChQxkxYgSVKlXit99+48cff2T69OkFKo9CoaBnz56sXbsWT09PatSoYTzm7e3NN998w/r166lVqxZ//PEHy5cvR6FQ5Fp2MIz9mDZtGkuXLqVp06bs3buXixcvGo+bm5szcuRI5syZA4Cvry9hYWHMnz8fd3d3aRkRQgghhMgHCUZEobz//vuMHj2awYMH07Rp01zTzJ49m2nTpjF27FgqVKjA0KFDOXHihPG4mZkZq1evxs/Pj6+++orExESqVq3K7Nmz6du3b4HL1KdPH7777jt69+5tsn/o0KFERESwbNky0tLScHd3Z/LkyezYsYNz587lmtfrr79OSEgI69ev57vvvqNz58589tlnjB8/3pjmnXfewdLSku+//57vvvsOe3t7unfvzujRo43d1IQQQgghRN4U+sKO4BVGaWlpXLx4ES8vL9RqdWkXx0RJDWAXRUfqrOyTOnrxSJ29eKTOyj6poxdPadTZs96TpWVElFk6nS7HIPInKRQKzMzMSqhEQgghhBCiKEkwIsqszz77jK1btz41TbNmzVi3bl0JlUgIIYQQQhQlCUZEmTVixAjefvvtp6axsbEpodIIIYQQQoiiJsGIKLPc3NxkViohhBBCiL8xWWdECCGEEEIIUSokGBFCCCGEEEKUCglGhBBCCCGEEKVCghEhhBBCCCFEqZBgRAghhBBCCFEqJBgR/xh6vb60iyCEEEIIIbKRYES8ECZOnEjv3r2N3z09PVm9enW+zo2Pj2fMmDFcunTpucvRsWNHZsyY8dz5FERwcDCenp788ccfJXpdIYQQQojiJsGIeCFt2rSJPn365Cvt5cuX2bFjh7SMCCGEEEKUMbLooXghNWjQoLSLIIQQQgghnpO0jIhC8fT0ZOPGjQwbNgwfHx86duzI+vXrjcfDwsLw9PRk7dq1dOzYkVatWnH27FkAjh8/zuuvv079+vVp27YtixcvRqvVGs/NzMzEz8+PVq1a0ahRI2bPnm1yPOv62btpXblyhcGDB9OoUSNatmzJpEmTiI2NJTg4mHfffReA1157jYkTJxrP+eGHH+jatSteXl706tWLXbt2mVwjIiKCjz/+mMaNG9OmTRu2bdtW4OfUqVMnpkyZYrIvLi4OLy8vfv75ZwBu3brFxx9/TIsWLfDy8mLIkCFs2rQpz5acJ7usAezfvx9PT0/CwsKM+571nIUQQgghSpu0jJSiTZEw5Q4kFOP7YWZmDQDMT+V+3NYMZlSBN5wKnrefnx/t2rVj6dKlHD9+nJkzZ2JhYUG/fv2MaRYvXswXX3xBeno6Xl5eBAYGMmTIELp168bIkSMJCQlh4cKFxMbGMnXqVABmzZrFL7/8wujRo3F3d2fNmjWcOXMGd3f3XMsRHh7OW2+9Ra1atZg3bx7p6enMmTOHMWPGsHjxYqZMmcKMGTOYPXs2TZo0AWDZsmX4+/szZMgQmjRpwuHDh/n0009RKBT06NEDrVbLoEGDSExMZObMmej1eubPn8/Dhw8L9Ix69erF5s2bmTp1KmZmZgDs27cPgK5du5KUlMS7776Lh4cHc+fOxdzcnB9//JENGzbQtm1bOnbsWNBqAcjXcxZCCCGEKG0SjJSir8LhWmpxX0Vl+CMj96P3M8AvvHDBiIeHB/Pnzwegbdu23L9/nxUrVpgEI6+++io9e/Y0fl+0aBE+Pj4sXLjQeF65cuWYNGkSgwYNQqPRsHHjRkaNGsX7778PgK+vLx06dMizHGvXrsXMzIxvv/0WjUYDgFqtZt68eWRkZFCjhiEgq1mzJlWqVCE+Pp5Vq1YxePBgRo0aBUDr1q1JSkpi/vz59OjRg0OHDnH16lU2bdpk7BLm7u5O3759C/SM+vTpw8qVKzl58iS+vr4A7N69m7Zt22JnZ8fFixepUqUKixYtonz58gDY29sTFBTEqVOnCh2MPOs5u7m5FSpfIYQQQoiiJMFIKRrnWhItI4YoxNxcletxWzNDOQoje5ABhi5Je/fu5cGDB8Z91atXN26npKRw4cIFRo8eTWZmpnF/27Zt0el0BAcH4+TkhFarpW3btsbjarWadu3a5Tmb1Llz52jatKkxEMkqS6dOnXJNf/78edLS0mjfvn2Ocvzyyy/cvXuXs2fPUq5cOZOxKfXq1cPVtWAPq2bNmtSqVYvdu3fj6+tr7Do2b948ALy8vPjpp5/IyMjgxo0bhIaGcuTIEbRaLenp6QW6Vpb8PGcJRoQQQghRFkgwUorecCpci0RBXL58A4A6deoUed7Ozs4m37N+sx8bG2sMDBwdHY3H4+Pj0el0zJ8/39iikl1ERAQWFhYAODg4mBxzcsr7QcXFxVG7du18lzs2NhaA/v3753o8IiKC+Pj4HGUAqFChQr6vk6VPnz6sWbOGqVOnsm/fPlQqlUlLz4oVK/j2229JSEjA1dUVDw8PzMzMCj37V36esxBCCCFEWSDBiCi0mJgYk+9RUVGAISjJ7bf6NjY2AAwbNizXVgtnZ2euXbsGQHR0NBUrVjQeywogcqPRaIiOjjbZl56eTmBgIA0bNsyR3tbWFoDly5ebXCNLtWrVsLe3N95Pdk8rR1569erFggULOH36NHv27KFTp05YWVkBsG3bNhYtWsTUqVPp3bs3tra2XL58mffeey/P/BQKBTqdzmRfUlKScTs/z1kIIYQQoiyQ2bREoR06dMjke0BAAB4eHnm+7Go0GmrXrs3du3fx9vY2flQqFQsWLODBgwc0bNgQCwsLfvvtN+N5mZmZHD9+PM9yNGrUiFOnTpm8kAcGBjJ06FCioqKMA8ez+Pj4oFKpiIqKMinH9evXWb58OQDNmzcnISGBwMBA43khISHcuXMn388ni6urKw0aNODXX38lKCjIZH2Uc+fO4eLiwptvvmkMkm7evElcXFyeLSM2NjZERUWZBCRnzpwxbufnOQshhBBClAXSMiIK7ejRo8yYMYOOHTty6NAh9u3bx6JFi556zscff8xHH32ERqOhS5cuxMTEsGjRIpRKJbVq1cLKyopBgwbxzTffoFarqVu3Lhs2bCAyMpIqVarkmud7773H1q1b+eCDDxg4cCDJycn4+fnRtWtXqlWrZmylOXz4MNbW1lSvXp0BAwYwZ84c4uLiqF+/PleuXGHhwoV06tQJjUZDq1ataNq0KePGjWPs2LFYW1uzaNEiVKrcx948S58+ffjyyy+xtbWlZcuWxv3e3t5s3LiRZcuW0axZM27evMnixYtRKBSkpuY+u0Hbtm1Zt24d06dPp2fPngQFBbF///4CPWchhBBCiLJAghFRaIMHD+by5csMHz6cKlWqsHDhQrp37/7Uczp16sTXX3/N8uXL2bJlCxqNhpYtWzJ27Fhj16VPPvkES0tLfvrpJ+Lj4+natSv9+vUjKCgo1zwrV67M+vXrmTdvHqNHj8bW1pbu3bszevRowDCI/JVXXmHlypVcvHiRFStWMG7cOMqXL8/mzZtZsmQJzs7OvPfee4wYMQIwdIXy9/dn1qxZfPnll5ibmzNw4EDjtLwF1aNHD2bNmkW3bt1MApq+ffsSEhLCxo0b+fbbb3F1deXVV18lLCyM8+fP55pX27ZtGT16NOvXr2fbtm34+voyZ84chgwZUqDnLIQQQghR2hT6wo6SFUZpaWlcvHgRLy8v1Gp1aRfHxOXLl4GiH8Du6enJ+PHjGTRoUJHmK4qvzkTRkTp68UidvXikzso+qaMXT2nU2bPek6VlRIhC0Ol0OQaRP0mhUOQYryKEEEIIIf4iwYgQhbB8+XKWLVv21DSurq4cOHCghEokhBBCCPHikWBEFMrVq1dLuwilql+/frRv3/6pabLWTBFCCCGEELkr1WAkICCAsWPHcu7cuVyPR0dH07NnT95++21Gjhxp3J+eno6fnx87d+4kOTmZNm3a8Pnnn5usGREXF8fs2bM5ePAgOp2Orl27MmnSJJNVuu/fv88XX3xBUFAQarWaV199lVGjRslLpHimihUr5rpGiRBCCCGEyL9SC0bOnj3LuHHjnprmyy+/zLGwHsDUqVM5cOAAEyZMwNramgULFjB06FC2bNli7KM/cuRIwsLCmDZtGqmpqcybN4/IyEhWrlwJGAKagQMHYmlpybx587h//z5+fn6kpqYyZcqUor9hIYQQQgghhIkSD0bS09NZu3YtixcvxtramoyMjFzTHThwgGPHjuUYdX/nzh22bdvG/Pnz6dmzJwC1a9eme/fuBAQE0LVrV4KCgggODmbz5s34+PgA4OLiwvvvv8+lS5eoV68ev/76K3fu3CEgIAAXFxcA1Go106ZNY/jw4Tg5ORXjUxBCCCGEEEKU+ArsR44cYdWqVYwfP5533nkn1zQJCQlMmzaNiRMn5ugylbXWRPb++u7u7tSsWZOjR48ChtW3HR0djYEIGFbU1mg0xjQnTpygbt26xkAEoHPnzmRmZpqsui2EEEIIIYQoHiXeMuLt7U1AQAB2dnYsXbo01zRz586lRo0a/Otf/+LLL780ORYSEoKTkxPW1tYm+93c3AgNDTWmeXK1bqVSiaurqzFNaGgo7u7uJmkcHBzQaDTGNAV148YNlMoSj++eKiUlBfhrXmlR9kmdlX1SRy8eqbMXj9RZ2Sd19OIpjTp71lIIJR6MPGvQb2BgIDt37mT79u25Hk9KSsLGxibHfhsbGx48ePDMNImJiQAkJiY+M40QQgghhBCi+JSpqX1TUlKYPHkyI0eOpHLlyrmm0ev1KBSKp+7X6/W5tlA8uT+vfArbulGjRo1/zArsL6K8fnbKGqmzsk/q6MUjdfbikTor+6SOXjyluQJ7XspUn6KFCxdia2vLO++8Q2ZmJpmZmYCheSdrW6PRkJSUlOPc5ORkbG1tn5kma2rf/KQRZcfEiRPp3bu38bunpyerV6/O17nx8fGMGTOGS5cuPXc5OnbsyIwZM547n4IIDg7G09OTP/74o0Sv+zyep74KqjTqRAghhBBFo0wFI/v37+fPP//E29ubevXqUa9ePRISEvj666+pV68eYBisHhkZSWpqqsm5YWFhVKtWzZjm7t27Jsd1Oh3h4eEmacLCwkzSxMTEkJiYaEwjyq5NmzbRp0+ffKW9fPkyO3bsQK/XF3OpRGlYtmwZAwcOLO1iCCGEEKIQylQw4u/vz88//2zysba2pl+/fvz8888A+Pr6otVqOXDggPG80NBQrl+/jq+vrzFNREQEFy5cMKYJDg4mMTHRmKZFixZcvHjROM4EDMGQSqWiadOmJXG74jk0aNAAZ2fn0i6GKAPq1q2Lm5tbaRdDCCGEEIVQpoIRT09PvL29TT5mZmY4Ozvj7e0NQJUqVejevTuTJ09m8+bN7Nmzh6FDh+Lp6Unnzp0BQ6Dh4+PDiBEj2LFjB9u2bePTTz+lffv2eHl5AdC7d2+cnZ0ZPHgw+/bt48cff+TLL7+kX79+VKhQodSewYvC09OTjRs3MmzYMHx8fOjYsSPr1683Hg8LC8PT05O1a9fSsWNHWrVqxdmzZwE4fvw4r7/+OvXr16dt27YsXrwYrVZrPDczMxM/Pz9atWpFo0aNmD17tsnxrOtn7/Zz5coVBg8eTKNGjWjZsiWTJk0iNjaW4OBg3n33XQBee+01Jk6caDznhx9+oGvXrnh5edGrVy927dplco2IiAg+/vhjGjduTJs2bdi2bVuBn1OnTp1yLKIZFxeHl5eXMcC+desWH3/8MS1atMDLy4shQ4awadOmPFtynuwCBYZA2tPT06S171nPOT8yMjJYsmQJ3bp1w8vLi6ZNmzJixAju379vTJOf+gKIjY3l008/pWHDhjRv3pxZs2aZrDOUmZnJ4sWLad++Pd7e3vTt29dkmu2s7mobN26kdevWtGvXjrCwMJNuWlu2bKF58+YEBgbyyiuv4OXlRc+ePQkICDApS1BQEK+99hr169enV69eHD16lLp167Jly5YCPR8hhBBCPJ8yFYzk1+zZs+nZsyd+fn785z//oXbt2qxatcq4+rpCocDf359GjRoxefJkZs+eTYcOHZg/f74xDysrK9asWUPFihUZO3Ys/v7+vPnmm0yaNKm0buuF4+fnh7W1NUuXLqVLly7MnDmTzZs3m6RZvHgxY8eOZdy4cXh5eREYGMiQIUNwc3Nj2bJlDBo0iDVr1vDFF18Yz5k1axbr1q1jyJAhLFiwgCtXrrB79+48yxEeHs5bb71FYmIi8+bN4z//+Q/Hjx9nzJgx1KtXzxgMzJ49m+HDhwOGrj1z586lZ8+erFixgpYtW/Lpp58ar6PVahk0aBAXL15k5syZTJw4kSVLlvDw4cMCPaNevXrx22+/mbyc79u3D4CuXbuSlJTEu+++S2xsLHPnzmXlypXUr1+fDRs2cPDgwQJdK7v8POf8mD17NuvXr2fIkCF89913jBo1isDAQGbNmmVMk9/6+vbbb3FwcODrr7+mf//+rF27lo0bNxqPT548mTVr1vDuu++yfPlyPDw8GDJkiDGIzfL1118zY8YMRo8enWuLSFJSEp999hlvv/02K1euxMHBgdGjRxMbGwvA1atXGTJkCE5OTixdupR//etfjBo1qsCBmhBCCCGeX6nOpjVy5EhGjhz51DSnT5/Osc/a2pqZM2cyc+bMPM9zdHRk0aJFT827atWqxTaoNj/OXN3JzsBFpKbnHEhfVLIG/psfzb2qLS1s6OU7isaevQqct4eHhzHAa9u2Lffv32fFihX069fPmObVV1+lZ8+exu+LFi3Cx8eHhQsXGs8rV64ckyZNYtCgQWg0GjZu3MioUaN4//33AUO3uw4dOuRZjrVr12JmZsa3335rnHxArVYzb948MjIyqFGjBgA1a9akSpUqxMfHs2rVKgYPHsyoUaMAaN26NUlJScyfP58ePXpw6NAhrl69yqZNm2jQoAFgGGfUt2/fAj2jPn36sHLlSk6ePGnsIrh7927atm2LnZ0dFy9epEqVKixatIjy5csDYG9vT1BQEKdOnaJjx44Ful6WZz3n/HZrio6OZvz48bz22msANGvWjJCQEH799VfA0NqR3/pq2bIlkydPNqY5cOAAwcHBDBgwgJs3b7Jlyxa++OILXn/9dWOZIyIiWLRoET/88IMxn/fee++pzyUjI4Nx48YZf+4cHR155ZVXCA4Oplu3bqxatQoXFxeWLVuGubk57dq1Q6lUMnfu3Hw9EyGEEEIUnTI1te8/zf7T3/AoJqRkLpaW++74JAg4822hgpHsQQYYuiTt3bvXZBxO9erVjdspKSlcuHCB0aNHG4MkMLx06nQ6goODcXJyQqvV0rZtW+NxtVpNu3bt8pxN6ty5czRt2tRkFrROnTrRqVOnXNOfP3+etLQ02rdvn6Mcv/zyC3fv3uXs2bOUK1fOGIgA1KtXD1dX12c8FVM1a9akVq1a7N69G19fX2PXsXnz5gHg5eXFTz/9REZGBjdu3CA0NJQjR46g1WpJT08v0LWy5Oc55zcYyQroHz58yK1bt7h16xZnz541lu3333/Pd301bNjQ5Lurqyvx8fEAnDx50ljG7GVu164dCxYsMHkWWcHl02SvNxcXF+CvhZ5OnjxJ9+7dMTf/65+/7t27SzAihBBClAIJRkpR5yZDSq5lxDzvlpHOjQcXKu8nB5Bn/WY/NjbWGBg4Ojoaj8fHx6PT6Zg/f75Jl7ksERERWFhYAODg4GByzMnJKc9yxMXFUbt27XyXO6u7Tv/+/XM9HhERQXx8fI4yAIUaT9SnTx/WrFnD1KlT2bdvHyqVyqTlYMWKFXz77bckJCTg6uqKh4cHZmZmhZ79Kz/POb/Onj3LtGnTuHr1Kra2ttSpU8dkLZ2sYCI/9WVlZWXyXalUGu8xq06yBzXZxcTEGLezfs6extLS0uQ68NcKsDExMTnyeNrPlxBCCCGKjwQjpaixZ69CtUgURHEubpP9BREgKioKMLws5vZb/awV74cNG5Zrq4WzszPXrl0DDN2DKlasaDyW9bKaG41GQ3R0tMm+9PR0AgMDc/w2HjCuR7N8+XKTa2SpVq0a9vb2xvvJ7mnlyEuvXr1YsGABp0+fZs+ePXTq1Mn4Yr5t2zYWLVrE1KlT6d27N7a2tly+fJn33nsvz/wUCoXxxTpL9jVz8vOc8yMhIYEPP/yQRo0asXTpUqpWrQrAvHnzuHLlCmDoUgYFq6/c2NraolAo2LBhQ66Bs4ODA6GhoQXKMy/Ozs45fl6e/C6EEEKIkvFCDmAXZcOhQ4dMvgcEBODh4ZHny65Go6F27drcvXvXZMY0lUrFggULePDgAQ0bNsTCwoLffvvNeF5mZibHjx/PsxyNGjXi1KlTJi/kgYGBDB06lKioKOPEBll8fHxQqVRERUWZlOP69essX74cgObNm5OQkGAym1NISAh37tzJ9/PJ4urqSoMGDfj1118JCgoyWR/l3LlzuLi48OabbxqDpJs3bxIXF5dny4iNjQ1RUVEmAcmZM2eM2/l5zvlx69Yt4uLieO+994yBiE6n48SJE8ayFaa+ctO4cWP0ej1JSUkmZQ4MDOT777/Ps2WvMJo2bcrhw4dNnt+Ts20JIYQQomRIy4gotKNHjzJjxgw6duzIoUOH2Ldv3zMnDfj444/56KOP0Gg0dOnShZiYGBYtWoRSqaRWrVpYWVkxaNAgvvnmG9RqNXXr1mXDhg1ERkZSpUqVXPN877332Lp1Kx988AEDBw4kOTkZPz8/unbtSrVq1YytNIcPH8ba2prq1aszYMAA5syZQ1xcHPXr1+fKlSssXLiQTp06odFoaNWqFU2bNmXcuHGMHTsWa2trFi1ahEqlKtSz6tOnD19++SW2tra0bNnSuN/b25uNGzeybNkymjVrxs2bN1m8eDEKhSLHwp5Z2rZty7p165g+fTo9e/YkKCiI/fv3F+g554eHhwc2NjZ8/fXX6HQ6UlNT+emnn7hy5QoKhQK9Xo9GoylwfeWmTp06dOvWjXHjxjFixAiqV6/OyZMn8ff3Z/DgwcauVkVh6NChvPLKK4wcOZI33niD0NBQFi9eDFCk1xFCCCHEs0kwIgpt8ODBXL58meHDh1OlShUWLlxI9+7dn3pOp06d+Prrr1m+fDlbtmxBo9HQsmVLxo4da+y69Mknn2BpaclPP/1EfHw8Xbt2pV+/fgQFBeWaZ+XKlVm/fj3z5s1j9OjR2Nra0r17d0aPHg0YBpG/8sorrFy5kosXL7JixQrGjRtH+fLl2bx5M0uWLMHZ2Zn33nuPESNGAH9NDz1r1iy+/PJLzM3NGThwoHFa3oLq0aMHs2bNolu3biYBTd++fQkJCWHjxo18++23uLq68uqrrxIWFsb58+dzzatt27aMHj2a9evXs23bNnx9fZkzZw5Dhgwp0HN+FltbW5YuXcq8efMYNmwYDg4ONGnShMWLF/Pxxx/z+++/06BBgwLXV178/PxYvHgxq1atIioqCldXV8aMGcOgQYMKlM+zVK9enRUrVvDVV18xfPhw3N3dmTRpEp9//jnW1tZFei0hhBBCPJ1CX9hRssIoLS2Nixcv4uXlZTK4tyworjEjnp6ejB8/vshfFEXxjvMRcOLECWxsbPDx8THuO3bsGIMGDeJ///tfviZDkDp68UidvXikzso+qaMXT2nU2bPek6VlRIhC0Ol0OQaRP0mhUOQYr1JWZJ8+Ny9mZmYoFIoSKE3JOn/+PKtXr2bChAlUq1aN8PBwlixZQtOmTQs0K5sQQgghnp8EI0IUwvLly1m2bNlT07i6unLgwIESKlH+hYWF5bkGS3Y//PADzZs3L4ESlayhQ4eSnp7OqlWrePjwIeXKlaNLly6MGTOmtIsmhBBC/ONIMCIK5erVq6VdhFLVr18/2rdv/9Q0WWumlDXOzs78/PPPz0xXrVq1EihNyTM3N2fUqFGMGjWqtIsihBBC/ONJMCJEIVSsWDHXNUpeBBYWFnh7e5d2MYQQQgghZJ0RIYQQQgghROmQYEQIIYQQQghRKiQYEUIIIYQQQpQKCUaEEEIIIYQQpUKCESGEEEIIIUSpkGBECCGEEEIIUSokGBH/GHq9vrSL8I8mz18IIYQQT5JgRLwQJk6cSO/evY3fPT09Wb16db7OjY+PZ8yYMVy6dOm5y9GxY0dmzJjx3PkURHBwMJ6envzxxx8let2itHnzZhYtWlQi19qyZQuenp5ER0cDMGDAAD744INiudaTP5dCCCGEKBhZ9FC8kDZt2sRLL72Ur7SXL19mx44dvP/++8VbKJGnFStWPHPF+hfR8OHDSU5OLu1iCCGEEC8sCUbEC6lBgwalXQQhqFKlSmkXQQghhHihSTctUSienp5s3LiRYcOG4ePjQ8eOHVm/fr3xeFhYGJ6enqxdu5aOHTvSqlUrzp49C8Dx48d5/fXXqV+/Pm3btmXx4sVotVrjuZmZmfj5+dGqVSsaNWrE7NmzTY5nXT97N60rV64wePBgGjVqRMuWLZk0aRKxsbEEBwfz7rvvAvDaa68xceJE4zk//PADXbt2xcvLi169erFr1y6Ta0RERPDxxx/TuHFj2rRpw7Zt2wr8nDp16sSUKVNM9sXFxeHl5cXPP/8MwK1bt/j4449p0aIFXl5eDBkyhE2bNuU5xiK3rkH79+/H09OTsLAw475nPef86NixI9988w1Tp06lWbNmNGrUiAkTJpCYmGhMk5GRwapVq+jWrRve3t706dOHX3/91SSP8PBwfvzxRzw9PQt0/e3bt/N///d/+Pj44OPjQ//+/Tl16pRJmm3bttGtWzfq16/PkCFDiI2NzZGPTqdj0aJFtGrVigYNGvDhhx/y6NEjkzQ7duygT58+eHt707lzZ9atW2dy3NPTkxUrVtCrVy8GDBjAiRMnTOoi62f+wIEDDBo0CB8fH9q0aYO/v79JPmFhYQwbNoxGjRrRunVrVq9ezfvvv2/ysymEEEI8t6grcOAT+KEhnJxX2qXJk7SMlKYrm+DEFEhPKLZL1MjMNGwczqOqLWyh5Qyo/UaB8/bz86Ndu3YsXbqU48ePM3PmTCwsLOjXr58xzeLFi/niiy9IT0/Hy8uLwMBAhgwZQrdu3Rg5ciQhISEsXLiQ2NhYpk6dCsCsWbP45ZdfGD16NO7u7qxZs4YzZ87g7u6eaznCw8N56623qFWrFvPmzSM9PZ05c+YwZswYFi9ezJQpU5gxYwazZ8+mSZMmACxbtgx/f3+GDBlCkyZNOHz4MJ9++ikKhYIePXqg1WoZNGgQiYmJzJw5E71ez/z583n48GGBnlGvXr3YvHkzU6dOxczMDIB9+/YB0LVrV5KSknj33Xfx8PBg7ty5mJub8+OPP7Jhwwbatm1Lx44dC1otAPl6zvm1cuVK2rRpw4IFC7h16xbz5s3DycmJcePGATBhwgQOHDjAyJEj8fT05LfffmPs2LGkpqby+uuvs2zZMoYOHUqjRo0YOHBgvq+7Z88exo8fz0cffcT48eOJiopi2bJljB49mgMHDmBhYcHu3buZMGECb7/9Nh06dODgwYMsWLAgR17Hjh0jIyOD2bNn8/DhQ2bNmsXMmTNZunQpAFu3bmXixIm8/fbbTJgwgfPnzzN79mzS0tIYPHiwMZ9ly5bx2WefkZycTN26dbl+/XqOa02aNIm3336bwYMHs3v3bhYtWkTdunVp164daWlpvP/++5ibmxvznz9/PtHR0fTq1atA9SKEEEKQmQYpkZAaZfgzJRKSH8GNbXAn4K90CXeh2fhSK+bTSDBSmk5/BTHXivUSqqyNtDwSJN2H036FCkY8PDyYP38+AG3btuX+/fusWLHCJBh59dVX6dmzp/H7okWL8PHxYeHChcbzypUrx6RJkxg0aBAajYaNGzcyatQo4xgPX19fOnTokGc51q5di5mZGd9++y0ajQYAtVrNvHnzyMjIoEaNGgDUrFmTKlWqEB8fz6pVqxg8eDCjRo0CoHXr1iQlJTF//nx69OjBoUOHuHr1Kps2bTJ2CXN3d6dv374FekZ9+vRh5cqVnDx5El9fXwB2795N27ZtsbOz4+LFi1SpUoVFixZRvnx5AOzt7QkKCuLUqVOFDkae9Zzd3NzynZeLiwsLFixAoVDQunVrTp48yZEjRxg3bhxXr15l586dTJ8+nf79+wOGZ5mYmMiCBQvo27cvdevWxcLCAicnpwJ1r7tz5w5vv/02I0eONO5TqVSMGDGC0NBQatWqxapVq2jTpo2x9alNmzbcu3ePgwcPmuRlZ2eHv78/VlZWAFy9epXt27cDhlaTBQsW0KdPH2M+rVu3RqFQ8PXXX/PWW29hbW0NQKtWrXjrrbe4fPlynuXu0aMHH3/8MQDNmzdn7969HDlyhHbt2vG///2Pe/fusXv3bqpWrQoY/h793//9X76fixBCiDIsI8kQCNwLhDpvw0u+T09/LwjuB0JaXLZPLKQ/3s5MAV0m6LWg0xr+zNrOSIKMxKfnD2BmAS3+UxR3VywkGClNTcYVe8tIxuOWEZX5U1pGmo4rVN7ZgwwwdEnau3cvDx48MO6rXr26cTslJYULFy4wevRoMrNabDC8KOt0OoKDg3FyckKr1dK2bVvjcbVaTbt27fKcTercuXM0bdrUGIhklaVTp065pj9//jxpaWm0b98+Rzl++eUX7t69y9mzZylXrpzJy3O9evVwdXV9xlMxVbNmTWrVqsXu3bvx9fU1dh2bN8/QXOrl5cVPP/1ERkYGN27cIDQ0lCNHjqDVaklPTy/QtbLk5zkXJBjx9vZGoVAYv7u4uBhfxk+fPg1A9+7dTc7p2bMnO3fu5ObNm9SqVatQ9zF06FDAMBvarVu3CAkJ4cCBAwCkp6eTkpLC5cuX+eyzz0zO69atW45gxNPT0xiIALi6uhIfHw9ASEgIjx49yvXnYcmSJVy4cIEWLVoApj/Pecn+M6NUKnF2djYOcg8ODqZmzZrGQAQMPwMFqQ8hhBBlQHoi3N5nCBb0WtBmwN2DcGOrIUgAuLAKev0EtV7Leb4uE45MhDPzi62IWhtXLmhqsCcpmbrJ6bxSbFd6PhKMlKbabxSqRaIgbjx+aaxTp06R5+3s7GzyPes3+7GxscbAwNHR0Xg8Pj4enU7H/PnzjS0q2UVERGBhYQGAg4ODyTEnJ6c8yxEXF0ft2rXzXe6sMQVZv8nPrRzx8fE5ygBQoUKFfF8nS58+fVizZg1Tp05l3759qFQqk5aeFStW8O2335KQkICrqyseHh6YmZkVel2O/Dzngsj+Eg+gUCiMZYuLi8Pc3Bx7e3uTNFn1lX1sSUFFRETw+eefc+TIEVQqFTVr1jQGg3q9nvj4ePR6fb5+Vp52D1k/D2PGjGHMmDG5liNL9p/nvFhaWpp8VyqVJtfK+nvyrDILIYQoo1JjYXN7iPj96el0GbDjDei8AuoPyXZ+DOzoD7d/e/a1zNSgMAOlGSjNDdtZ382twMrJ+NGpHUhWqIjVZnL+0TX23r+MPsUwljT24n95pY100xJ/MzExMSbfo6KiAENQkttv9W1sbAAYNmxYrq0Wzs7OXLtm6LYWHR1NxYoVjcdyG5ScRaPRGNeUyJKenk5gYCANGzbMkd7W1haA5cuXm1wjS7Vq1bC3tzfeT3ZPK0deevXqxYIFCzh9+jR79uyhU6dOxpfjbdu2sWjRIqZOnUrv3r2xtbXl8uXLvPfee3nmp1Ao0Ol0JvuSkpKM2/l5zkWlXLlyZGZmEhsbaxKQREZGAuQIUgpizJgxPHz4kE2bNlGvXj3Mzc05fPgwv/32m/HaCoUiRz0VtI6yfh6mTJlC/fr1cxwvylYLZ2dn/vzzzxz7o6OjqVatWpFdRwghRDHJSIFtffIORCxs0dXoiy4tDvOb20Cvg31DIepP0LgaulVd+QliDGMO9Qol4dVfI97GjTSFihSFknhtBnHpacSmJ5GmTUOv16Pn8S8o9cYt9DotGdp0tIkZpMfcJjohCJ3urxZ+HvdqUKts6NvOtBdBWSLBiCi0Q4cO8fbbbxu/BwQE4OHhgbOzs8msTlk0Gg21a9fm7t27eHt7G/dfuXKFuXPnMmrUKBo2bIiFhQW//fabsTUnMzOT48ePG/vtP6lRo0Zs376dpKQk44t4YGAgQ4cOZc+ePcaB41l8fHxQqVRERUXRuXNn4/4tW7bw22+/4efnR/PmzVm1ahWBgYHGsR4hISHcuXOHVq1aFeg5ubq60qBBA3799VeCgoL4+uuvjcfOnTuHi4sLb775pnHfzZs3iYuLy7NlxMbGhqioKHQ6HUqlYUK8M2fOGI/n5znnFoQVRuPGjQHDYPPsLU27du3C0dHROOlAVjkL4vz588ZZqbIcPXoUMLSMWFpa0qBBA/bv32+yhszhw4cLdB0PDw/s7e15+PChyfM6evQoa9euZerUqbm2khVGkyZN+N///sfdu3epXLkyANeuXePu3bvGZymEEKLk6PV6ElOiSU6LJy09idT0RFLTE43bWp2WmpWb4+rkaehateMNCD8GQLLCnOOWVVCaWWKmsiQWFefSdURfOQ56HQNtqtMw6abhQmcX5bh2qtKCb/WOXLl1BjiT4/jzsrV2on3D92hT/22sLe2KPP+iIsGIKLSjR48yY8YMOnbsyKFDh9i3b98zV9n++OOP+eijj9BoNHTp0oWYmBgWLVqEUqmkVq1aWFlZMWjQIL755hvUajV169Zlw4YNREZG5rmmw3vvvcfWrVv54IMPGDhwIMnJyfj5+dG1a1eqVatmbKU5fPgw1tbWVK9enQEDBjBnzhzi4uKoX78+V65cYeHChXTq1AmNRkOrVq1o2rQp48aNY+zYsVhbW7No0SJUKlWuZXiWPn368OWXX2Jra0vLli2N+729vdm4cSPLli2jWbNm3Lx5k8WLF6NQKEhNTc01r7Zt27Ju3TqmT59Oz549CQoKYv/+/QV6zkWldu3adOvWjTlz5pCUlISnpycBAQHs3LmTKVOmGIMQOzs7Ll26xKlTp2jSpInJGJS8eHt7s3XrVjw9PSlXrhz79u1jw4YNAMZnM3LkSAYPHsykSZPyfBbPYm5uzsiRI5kzZw5gmDAhLCyM+fPn4+7uXqQtIy+//DIrVqzgww8/5OOPP0ar1bJw4UIUCkW+nokQQoj80em0pKb/1WtAq8sgLukRcYmPiEt8wP3oG4RHXCbs0WWS0+Kempdar6ORvQudzTOpGGGYXj4NBf5UJCRNgWGWoCdmClIoWJ2spycO9CQmR573UbFS70KkonDvFdkpleaYm1lQ3rYSzg7VqGDvjluFOjSo2R2Vufq58y9uEoyIQhs8eDCXL19m+PDhVKlShYULF+YYyPykTp068fXXX7N8+XK2bNmCRqOhZcuWjB071th16ZNPPsHS0pKffvqJ+Ph4unbtSr9+/QgKCso1z8qVK7N+/XrmzZvH6NGjsbW1pXv37owePRowDCJ/5ZVXWLlyJRcvXmTFihWMGzeO8uXLs3nzZpYsWYKzszPvvfceI0aMAAxdofz9/Zk1axZffvkl5ubmDBw40Dgtb0H16NGDWbNm0a1bN5OApm/fvoSEhLBx40a+/fZbXF1defXVVwkLC+P8+fO55tW2bVtGjx7N+vXr2bZtG76+vsyZM4chQ/7qj5qf51xU/Pz8WLx4Md9//z2xsbF4eHjw1Vdf8fLLLxvTfPDBB0ydOpXBgwezd+9eXFxcnpnv7NmzmT59OpMmTUKtVuPp6cm6desYMmQI58+fp1mzZrRq1YqlS5eyePFiduzYgbe3N+PGjWPGjBkFuod33nkHS0tLvv/+e7777jvs7e2NP0NFGSSoVCpWr17N9OnTGT9+PLa2tgwdOpTvv//e2KonhBCi8NIzUjh47nsCTn/7zCAjN1Z6LZVJozLpVNanUZk0KpCBMibEmEYLfKtw4Y6ZLZbmFiZBj8bKAQfbl0hOjSMqPoxdivL8obehCmmkoSANJUkoCcUSnUKBg20lWtd/ExtLB1TmlqjMLLC2tEdj5YCNlQNqlY3x/yHjnyhAoUChUGKuVKFUmvYAedEo9IUdJSuM0tLSuHjxIl5eXqjVZSsCvVxMA9g9PT0ZP348gwYNKtJ8RfHVmSg6ha2jq1evEhYWZjKWJzExEV9fX8aNG2dcoFMUPfl79eKROiv7SruOMrXppKYnodVmkJkWx+1bv7Ht3I9EJz169smAjV5LTQsVdaxseEmbiFNaJLbpsU89Rwv8ZOaKTcPhdG4yBDubCuj0OtLSkzBTmmOhsjKW7fD5dewJXkZKWs5ZU8vZVKRb82H41nu9RFsvSqPOnvWeLC0jQhSCTqfLMYj8SQqFIsd4lbIi+xS2eTEzMyuWrkNarfaZM4UplcpCjTMp6xISEhg+fDgffvghLVu2JDEx0dgqIoseCiFE7jIy07gXeZXbDy8Qee8MuqhLWMSHYJsSgTPpuJCBI5k4AvVQEIaaO6hRlHNHqTS86pqhx06ppJxCj40+A9vkB1ikPMq1h5UJpTk41iOpXHVCdUpiHb15pfEw7Gz+ml1TqVBipbY1Oc3czIJOjQfRrM6rHDq3lpiEe5S3c8XRzg3HcpWpVqlhiQQh+2Lhq3Do7wQDi2a4aJGTYESIQli+fDnLli17ahpXV1fjuhhlyZO/mc/LDz/8QPPmzYv8+l26dCE8PPypaUaMGGGy2OHfRZMmTfjqq6/47rvvWLt2LSqViiZNmvDjjz/ma9pgIYT4u0tOjefP20d4GH2TRzEhPIy+SWTkNXx0MbTRx9P2qZEDqNFTnVSqkwpxz5h690lmFuDkDc6NoGJjqNjI8N3cEhugXiHux9bakT6tPi3Emc9vVwy8ellPBgrOJOr5t3PZHJsowYgolKtXr5Z2EUpVv379aN++/VPTZK2ZUtY4Ozvz888/PzNdcU016+/v/8wFHYty+uGy5uWXXzYZTyOEEMIgIzONZRv6YhtzCTu0OKKlpj6ThiRiQ969ETIUZsRZOJCusqWCNhFVSj7W0zK3hAo+4Pw46HBuBE71DAHJCy78YTyzj4XjX6EWOnNDDw3zc5dRNK9byiXLnQQjQhRCxYoVi2x63JJmYWFhMoVtSfP09Cy1awshhCi7jp/5hgHRR6hERp5p0u3cwa0dKmcfFOXrgGMdVLaVcVJk69qbeA8enoW0bLNYKZSPFwd0BpuKYO1s6IL1N3HzTjRb9l3mvwFXOJVpCcP6weNAhLOXcdh7CD6UYEQIIYQQQogcEpOjcTzxn9wDEaU51OgLDT/CwrWNcTG/PGleMnz+xvR6PaevPWJZ8AP2RGTyyL48VPSC4S1B+dfzsbx6i4Hxt5m46u2n5Fa6JBgRQgghhBCl6tb2N6mvM0zFm660wKLtXLCpZGjFcKwH1hWekcPfm16v51pYHN9fiGR3ZCZXVBrS3CpBjYpQI/dzmpulcvDdaliZeZRsYQtIghEhhBBCCFFqov/cSL3w34zf0zouw8JnyFPO+PvS6eFaip7dd5PZfTeZ6yl6orRKklQW6GxtwcEeHHI/V63NxEOtp66dCl9bGO5iiVXZnNTThAQjQgghhBCiZOgy4fKPELIHMpJAm4b13cNkvTPfqNSOGv+QQCRFC1uj4XSinj+i07makMl9hQWZKhVgA9Y2YJ33+eqERLx1ybxRzYbX3G2oqjZ/Zg+2skiCESGEEEIIUbz0OrRXN6M9MgGLhDsmhywf/3nTzBbXf20t+bKVsN8TdMy5lsL/ktWkmJkDCkANFnmvO6JISsEqLZXqulS6Oprx77r21HPQAJqSKnaxkWBECCGEEEI8P70eEsMh+irJ908Sfy8YffIjFKkxWKU8pFx6DHn1GrqHBREt51LdKo8+SC+IqAzD+h4nE0FjBhVV4KTUce5uHAGRmVwzsyZFYwPYkONh6PQQm4Ay/CGV0xLxLaeku4cd7Wo5UdVZg0JhVRq3VOwkGBFCCCGEEAVmlhaBVewFiFoP94PhwSlIjwcMvYvy6mEUipqdivLEqMtjobbHwqo81Sq3ok+ToSVW9ud1LhF+iIAUHagUYKaAs0lwPJ5cVkRRAg5Q7ondGZlw5jLq83/SxElNF09HOjauQtMu7liqVSVyH2WBBCNCCCGEECJ3makQcQGSH0JyBCQ/gEfn4X4wtZ7obvUsYai55NIO+wYf8H71jthY2hdLkYvbqgcwIkRPhr4QAzQyMjELe4BndARvlMugRxdXGn78GubmL8BI82IiwYgQQgghhDClzYA/voHAGYZAJB8SUBKOmgdYEGlmRcVqXbGv6IO6nDvW9h5UcKxJNwubYi540dPr9Vy5FcmeoBC+VlTghns1DOM8chERA+evwsUbhu/lNGgqOVC9kh2dnC14y9uJhm1eQql0K7Hyl3USjAghhBBCCANdJlz9L5yYDLE380ymVai4b2bHda2WUCwIxZIozLFQWdPG5226Nh6MnY1TCRa8aIU9iGdXcCg7LzzkyKM0YsuXB68a4Or8V6KDp+D4eVAqwUwJ8UlYxsbiVcMZ71rOtGxQmbZNqlLT3RHFizjNVQkpUDCSkZGBSmXow3bkyBHu3r1Lp06dcHFxKZbCCSGEEEKIEhAXAn+shktrIPGeyaHMKp24b27HrZg7hMSG8RAV4Vig0ymMDQQWKmu6+LxDx8aDsLV2LIUbKBy9Hv5MgRPRmewISeB0gp5HmJNpZQUV6kOnXE7KyOSlfUfplBGDR88aVHYph5uLHdVc7alepTxmZsoSv48XWb6CkUePHjFixAhatWrFJ598wvfff8/cuXPR6/UsXLiQ9evXU7t27eIuqxBCCCGEKCidFpIfQfxtiLkK0Vch9rphX2qM4ZMYluM0baUWBFhXZ+ftM2h1oYadCtOpZC1VtrRt8DYdGw9EY1W+BG6maNxL0/PVlSTWxZgRZWEFmIOZA9g//bwqigzW1YO27TqURDH/EfIVjCxYsIDbt28zbNgwAFavXk3z5s2ZMGECU6dOZcmSJXz99dcFvnhAQABjx47l3Llzxn2pqan4+/uza9cuIiMjqVq1KkOHDqVnz57GNOnp6fj5+bFz506Sk5Np06YNn3/+ORUrVjSmiYuLY/bs2Rw8eBCdTkfXrl2ZNGkSGs1ff4nu37/PF198QVBQEGq1mldffZVRo0ZhYWFR4HsRQgghhCh1GckQfhRuB0DYYUi4Ywg69DnneMqdAqp152HVXvif/5nIh0EmR8vbueJVrQPulRqgTbKlnHUl6tatW/T3UQgpWriTDqGpEJoGUZmQpIXo1EzuxacRkZRBVKqWmAyIsHcAMw3k9sqXnIo6LRUnMz3V7FS0cbGiub0ZjWzAzUL1Qi4sWJblKxg5duwYY8aMoUOHDvz5559EREQwbdo06tSpw8CBA5k6dWqBL3z27FnGjRuXY/+0adPYv38/o0aNwsPDgwMHDjB69GgAY0AydepUDhw4wIQJE7C2tmbBggUMHTqULVu2YGZmmI1g5MiRhIWFMW3aNFJTU5k3bx6RkZGsXLkSMAQ0AwcOxNLSknnz5nH//n38/PxITU1lypQpBb4fIYQQQohSkxwBBz+B67+ANj3/5ymUoLYHm0pQ6zW0dQZw4EYAvx5bgE6XCRi6YLWo93808exDtUoNjeMfLl++XAw3UjCZetgeDcsfwME40OeaytzwsSD34OPabTShd2lub8Zrng683qIKjg72xVhqkV2+gpG4uDiqVq0KwIkTJzAzM6N58+YA2NnZkZ6e/x/69PR01q5dy+LFi7G2tiYjI8N4LDo6mq1bt/LFF1/w+uuvA9CyZUvu3LnDd999R8+ePblz5w7btm1j/vz5xuCkdu3adO/enYCAALp27UpQUBDBwcFs3rwZHx8fAFxcXHj//fe5dOkS9erV49dff+XOnTsEBAQYx7yo1WqmTZvG8OHDcXJ6cQddCSGEEOIf5MZ22DfE0ALyJGtnQ6Bh4wI2L4FDLShfG8p7gsYVLDSgUJKYEsOJPzZx5Od3iU38a/asys71eL/nIio6VCvBG3q2aymwMRL87+l4oC3EGI34RCrfCqGfTToDWrhS/71WMsi8lOQrGKlYsSK3bt2iefPmHDhwAC8vL2N3p5MnTxZoAPuRI0dYtWoV48ePJzY2ljVr1hiPJSUl0b9/f1q3bm1yTrVq1bhw4QIAQUGG5sL27dsbj7u7u1OzZk2OHj1K165dCQwMxNHR0RiIADRv3hyNRsPRo0epV68eJ06coG7duiZl79y5M//5z38IDAykT58++b4nIYQQQogSl5ECB0bAxe/+2qcuBzX+BVU7Q+WOoKmU66laXSbhEVe4GX6aW/dOczHkEBmZqSZpOjYaSJ9WY1CZq4vzLvLtZir8cF/LunuZhCiyypQtEImKhZBwiIw1fBKSsFMpqOxgSVVHG2pU1OBZyZY6buVoUt8R2+7eJX8TIod8BSMdO3Zk/vz57N+/n7NnzzJ58mQAvvzySzZs2GAcS5If3t7eBAQEYGdnx9KlS02OVa5cmenTp5vs02q1HDlyBA8PDwBCQkJwcnLC2tp0XU83NzdCQ0ONaapUqWJyXKlU4urqakwTGhqKu7u7SRoHBwc0Go0xTUHduHEDpbJszaCQkpIClI2mVJE/Umdln9TRi0fq7MUjdfZsFS/OpPydDcbviU6tuV9/JpmWj8fQ3o0FYolOvMv1+4d5FHed5PRYUtLiSEmPQ6fPzDXfKk6NaOTxGq7lvblx/Vae1y+JOorTKdkcrebnZDvu2pYHzEDxxAKBf9yAgycxu3QD7+oONK3nTNPWFfCu6UY5TW79suIIuxtXbGUuy0rj75VO9/TxSvkKRsaNG0d6ejonT57kvffe48033wQMrRSvvfYaH374Yb4LlH2QeX4sWbKEW7du4e/vDxhaT2xsci6YY2Njw4MHD56ZJjExEYDExMRnphFCCCGEKIvM0iKwD/sZAJ3Sgkd1JhBTpT86dCQk3ycmKZyo+BBuPDhGZELeAUUWczNLar/UgfpV++CgqVzcxc9VpM6Mgxm2nMqw4mqSgjCdBSmWVmAG2D6R+PZ9FGf+pE5kGK3dLGn2SiUaTPDG2lKW0HvR5KvGVCoV06ZNy7F/69atmJubExUVhaNj0c8pvWrVKlasWMHAgQPp2LEjYFgFM7c+fdn36/X6XFsontyfVz6Fbd2oUaMGanXZaMrMkhX51qlTp5RLIvJL6qzskzp68UidvXikzp7h6DrQGcbdKhsMg/rvcvS4H3+GHiZTm5HnaQoUWFvao7EuT0UHD6q7NqGGa1PcKtTBzExVoCI8Tx0law3drs5Hp3HgTiKHU1WEWNpinKoqtwaNB1FYn/uTLqpk+jd+iW6TW+JQzqrA1/4nK42/V2lpaVy8eDHP4/kKRlatWsXQoUNznmxuzu7du5kxYwaBgYGFL+UT9Ho9c+bM4fvvv+ett95i/PjxxmMajYakpKQc5yQnJ2Nra2tMExERkWuarLEuT8sn+/S/QgghhBBlSnoC/G7oMaJXmLErTcnedb3Q6bW5JnerUIcmtV+mQY1uONi9hJmy5FsPMnQQmKDnx9AU9sTCHVVWd3s1KNSQW0yRkAwR0TjFxdJbncrQxhVp9korWVTwbybf64xYWVkxYMAA4764uDimT5/Orl27jOM5ioJOp2PChAls376dDz/80DitbxZ3d3ciIyNJTU3F0tLSuD8sLIzGjRsb05w9ezZHvuHh4caB6e7u7oSFmS7wExMTQ2JiItWqla0ZI4QQQgghjP5YDWmxAJxX2rH78nbjIY2VA+4uDXAu70FFh2pUf6kJLo41SqxoOj2cS4I9sXAqEUITMrmToiVWYY7ezAywhrwaYB5Gwdkr2Fy/RYeXrHnF152eXWvykrNbiZVflLx8BSMjRoxg1qxZWFpa8vrrr3Po0CEmT55MTEwMQ4cOZcSIEUVWoDlz5rB9+3YmTpzIv//97xzHfX190Wq1HDhwwDi1b2hoKNevXzeWw9fXl5UrV3LhwgXq168PQHBwMImJifj6+gLQokULpk+fzoMHD4wzau3fvx+VSkXTpk2L7H6EEEIIIYqMNoPMU/OML3B7dDagAHMzCzo1HkzXph+gtsg5JrZYi6SH/bGwIRJ2xeiJyMzeDd4czHN53Qx/BOGPqJCZSj1bM9pVUNHeVUPt1vWp6NRSptn9B8l3MAKGxQb37t3LsWPH8PT0ZMWKFdSrV6/ICnPp0iV++OEHWrVqRcOGDTl//rzxmFKppH79+lSpUoXu3bszefJkEhMTsbOzY8GCBXh6etK5c2fAEGj4+PgwYsQIxo8fT2ZmJnPnzqV9+/Z4eXkB0Lt3b/z9/Rk8eDCffPIJjx494quvvqJfv35UqFChyO5JCCGEEKIoaHWZXNgxkIZJ9wG4jBXhCjUNa/bgX20nUt7OtdjLEJMJd9IgMgN+T7fl9wxLdgZpidJnzXCVSxCRlAJxiZg/isIzKZZu5fR0r+dM8x41sNNY5kwv/lHy3WkwKyBZtmwZ7du3Z/ny5cbVzovKgQMH0Ov1HD9+nOPHj5scs7a25ty5cwDMnj2b2bNn4+fnh06no2XLlnz++efG8igUCvz9/Zk5cyaTJ0/GwsKCTp068dlnnxnzs7KyYs2aNcyYMYOxY8dia2vLm2++yaefflqk9ySEEEII8bwSkyIJ2NIf30dHjPtO2tRkWLcl1KvWrtivH5wA8+/BL1Hw10StuXSfSs+Aq6Hwxw0Ul2/RrJI1PX2r0aNtTRr3rVXmlkAQpU+h1+v1uR3YtWtXriesXbuWS5cuMX78eJNVyrO6TP0TZc0S4OXlJbNpiecmdVb2SR29eKTOXjxSZ48l3if+2H/gz/XY6dONu2OtX8J60HUsLKyfcnLBpergt1gIT4dEreGzP1bHicSnBBFaHVy6AYEXcL57lx7N3enRpiadfT1wdCja8onnU5qzaeX1npxny8inn36KQqEge6yS/fusWbNM9v+TgxEhhBBCiCKVFgen5qE7PR87bZrJoUwLe+z/9T8ookBEp9Ox/1o0C0MzOKguT1qOF8ZsgUhCMvxxHRKSIDEZy9QUOlhn0sPnJTp83oZ6NZ1lvIcokDyDkR9++KEkyyGEEEIIIQAurIKjkyA12hgG6IAQC2ecW03Ftv5AMC/8WAudHq6m6NlwKZpfQxL4U2tBemUXsHtK68eDKPgtEIJ+p2mtCvRoU5PaDdV416iEl1fRjR8W/zx5BiPNmjUryXIIIYQQQogLq2DfB8avWuA4doRVe5XXXl6JRR5BiF4PR+PheALcSzd8HmaAlRJcLKCiuZ7ouGSOR2sJMbMiQ6UCHMHtiUWrtTo4fwXNrbso0tIhPR2r9HQ6u6jp2asGXWd1oEJ5w2xdWV1+hHge+R7Anpqayk8//cSRI0d4+PAhS5Ys4ciRIzRs2JBGjRoVZxmFEEIIIf7+bgdAwEfGr2exYYeiPBU8ujGkz3LMzXIuSx6TCT88ghUP4UrK0zJXADaQR4OKZUIiLVKiGF5JSc9BNbCxrvtctyJEfuUrGImNjWXAgAHcuHGDqlWrcvv2bdLT0zl69ChLlizhhx9+wMfHp7jLKoQQQgjx9xR1BX79P9BlAnAEOzYrnKhZuQWDei81CUT0eghOhBUPYFOUYdB5gcQnobh9j6rpSfSqYsMw35eo56wBNEV3P0LkU75XYI+IiGDLli3UrFnTuFbHsmXLePfdd1m+fDmrVq0q1oIKIYQQQhSINgNSo0Cn/WufmRqsyoOiGKeY1eshMwUyEiEjCdIT/9rW6w3XVihBlwGpMZAaDWfmGwatY1g/5GeFE1VdfBj88kqupVkSEg9h6fBndBo7o/WEKHNp4rh5F46fh/uREJsAcYmgMgd7WyycylG3diU6u1nTy6sizdu7Y2WZ11LoQpScfAUjAQEBfPzxx9SpUwet9q+/0BqNhkGDBvHFF18UWwGFEEII8Tek10NcCCQ/NLQG6DJBrzX+qXkYgllGAsT/D5LuQfIjw3lKc1CYGdJmvehnJhvyy5KRAEkPICUy92srzMDKCWwqgm1VsPeAch5g42I4pni8jlpKpKF8SQ8gPQ606Y8/aYY/dY+/Z6Y+DjayBR/kunLCM91HxWpFRcztqhPktZovz9kQZ9LyoTaZ3IrUNAi8AIfPwN0Hxt1mZgqa13ejU4tqdGrhQYsGbqgt8t07X4gSk6+fyoSEBNzcclnYBrCzsyMpKalICyWEEEKIv4HkR/DgtOFlXptqaC1IjYaHZ+DBKcN2HioXZ7n0WkOQkfwQIi4U55UKJA4zVigqEWVRiV+qryEh0SHvxLfvw6HTcPIPLPU6qld2oHpHTzzdHWnX1J22Tatia1O21j4TIjf5Ckbc3d05ePAgbdu2zXEsMDAQd3f3oi6XEEIIIcqqzFR4dN6wbW4JZpaGwCL2OsTegKjLhmAj4U7plE9hZmj1sHYBa2dQZuuOlJkEyRGGQCklAvQFHXCRu3SFigyFkjQUpGFGusLwyVSq0JpZojO3ApUNKpUVanMrLFWWpGszuBP7gPDEByQBf2JNgrkdv9b+jgS1qyHjlDTDiuZhD1HExlPTTkVLVxtaulhRc5AXNaa35SVnW1nZXLyw8hWMvPXWW0yfPh0zMzM6d+6MQqEgPDycU6dOsX79eiZMmFDc5RRCCCFEactIgQsr4dRcQ2vH81Dbg0szsK8BZipDAJHVBUtpTkRUNDozayp6NARbV7Cu+HicxePuXAolqGxApQFza9MxIGaq/I0J0WWijb3FjT83c/fqNlLj76DXa1GgRwEkY0b8408ySjJRkIkC7ePPX9ugf3KhP/3jjw7IBNIygbjHnycoDAPHtQoVu2v6E2VdG46fR3nkNE1soEPTqrTv4U6rRs2ltUP87eQrGOnfvz+3b99m7dq1/Pjjj+j1ej755BPAEKi8/fbbxVpIIYQQQpQgvR4SwiDq4uMB1jGQdB8urs5/EGJuCRUagktTcKgJ5laGfebW4ORlCEKeslJ35OM1LCrWqVMUd5RDSloCR35fx5HzPxKX9PDxXjvDDLjPYK0uR0ZmKhlPrIwOYKGyRq9QkaHTk6nXodBlYKbPmS67RFVF7ti34WLFd4hW1uCVK7/zQXMbWg17BztN4Rc3FOJFkO+RTBMmTOCtt97ixIkTxMTEYGdnR4sWLfDw8CjO8gkhhBCiKCWEGbpRZSYbBltnfTKTDQOvo/6EBycNwcfTuHc3DPrOGgui0hgCDIeajz+ehhaKMujqnUDW/zaemATTe3SwrYSzfTXsbSthr6mIHj2J6SmEJCaTiBpLRx+snRqisqlCbKae8JhHPIwMISo5mQc48cjchUQbR8MMVtkodWmotYmoM+OwyojEJiMC64wIAMLtWhBl5QkKBV1staypZYZrJ1kuQfxzFGhahcqVK/Paa68RHR2Ng4MD5uYyK4MQQgjxwgg7BpvaUtiZngDw6AO+U8ClSZEVqzCSU+N5EH2Dh9E3iYoPx0qtoZzGBXsbZzTWjqhVVliorLEwt8JMaY5CoSRDm8b2Y34cOve9SV513dtjX+td7pZrjVapJEEBkXrYGwsH4yA9e8+oyMcfFIDL43EpTy+rTqkmRakmReVIrJXpL3GVwOuOMPYlaGZr9ryPRYgXTr6jiRs3buDn50dgYCAZGRn897//5YcffqBOnTq8//77xVhEIYQQQhSJi9+Sr0BEZQMVm0DFxmBTyTC+w9IBHOuBY+1iKVpKWgKhD37HWm1HBXt3ALS6TELvn+dG+GnuPrpIXNIjEpKjSEiKJDktl7EXBeTxUmM6t/uSKbE1+F80uQ7nKJCkFMySU7CPj8cjKZZGZunUr6CGSs7E2dvzQGVJul6BUmEIZZzM4V1n8JCeWOIfLF/ByLVr1+jfvz8ajYZXXnmF//73v4aTzc2ZO3cu5cuX5+WXXy7WggohhBDiOej1EPqbYdtMDc0mPh4A/sRH4waOdUFZMr+lj0m4z6Fzazn+x0ZS0xON+y1VdmTq0sjMZVzG8zI3U9HTdzS33QbR9rYZcdqnJI5NgPNX4cYd0OlBqQSlAke1ksoac6o7WFK3ojUtajrR0KciLhUcUCjKF3mZhfi7ylcwMn/+fNzd3fnxxx9RqVRs3rwZgC+//JLExETWrVsnwYgQQghRlkVe/GsciGsbaDmtxC6t1+tRZBusrtVmcPXuCU5d/h9nru1Cp8vMcU5qRnyueZmbqbC1dqKcpiIu5WvgUr46FeyrkpqeRGziA+ISH5KUGkd6RjJpGcmkZySj0+vQ63WkZmpJNKvInxWH8X+pPiSGZAu4EpJhx2FISgVzM1Aq4M4DCL2HnY0F7ZpWpYWPG83ru9HE6yXK2UpzhhBFIV/ByKlTp5g5cyZWVlYmK7AD9O3bl08//bRYCieEEEKIIhK6969t924lcsm7Dy/yzY6PiE+KoIJ9VSrYu2NpoeFSyCGSUmNM0iqV5jSs2QNzMxURMaHcj7qFUqGkVpVmVHdtSvWXGuNkXxVLC41JYPMknR5up8HlFDgVmcahu4lcTVXwyMIKrbVV7icF/QEbdkNiMmBYvbyFjxtdetWkS8tuNPN2xdxcxnMIURzyFYzo9XrU6tzntc7IyECvf46BcEIIIYQofiUcjITeP8/yrf8mJS0BgPtR17kfdT1HOksLDa2936Rdw3dxsK1k3H/58dS+dfI5tW9YGqx6oMf/no5IfVbgoAZLNeTWiJGWAZdvwaHTWF0PwcfThSZeXnT29aB9M3dp+RCihOQrGPH29ubHH3+kU6dOOY5t374dLy+vIi+YEEIIIYpIRjKEHzVs21QyrPNRjG6EncJ/22DSMpIAsFLbkZaehE5v6F1hbmZBvWodaOzZC69qHbBQWbHqAay8Ba+Uh8/c8nedFC1se5jB4hspnFRq0CuVQB4tGPFJWMXE4paRQv30eJqrM6hWXUPdrl3wrOaEmZmsYC5EachXMDJ8+HAGDRpE37596dixIwqFgr1797J8+XIOHTrE6tWri7ucQgghhCissCOQNRDcvetTFxt8Hnq9nvPX97Bu73jSM1MAqP5SEz589RsszC2JjA8jISkS1wq1sVLbPj4HZtyFqXcNeZxNgj2xMEOhwtUsA70erqTA0XhI1xuu8SAqid3hKVywtEdroQLzbOuZ6PRwNQTuPMAlM5X2bja8XMeRrs1fwtHBtVjuWwhRePkKRlq0aMGSJUv48ssvWb58OQCrVq2iYsWKzJ8/H19f32ItpBBCCCGeQ/YuWlWLvouWXq/nz9Aj7AxcxJ2Hfxj316rsywevrEStMizEUdGhGhUdqmU7Dybehnn3TPMLTIC+imr0tojjzDk911KzB08KQAN2GtOT4pNQHj9H68RHvNbYlV6Da+NRWWa1EqKsy/c6I506daJTp06EhoYSHR1NuXLl8PDweOogMiGEEEKUAbcfT+mLAqp2fu7souPDuXAzgKi4O0Qn3ONB9E0eRt80SVPXvR1v9FjOtHuWpOng387gbfPX8cgM+M8dWPnwr30dkyM4bW5LvIUlCXozNqQ9I5hIScP66i1a6RL4oG45uk9qho21xXPfnxCi5OQrGOnfvz9du3alS5cuuLu74+7uXszFEkIIIUSRiL8LUX8atis2AusKhc4qOj6cvSf9Cbz0c67T8QK4lK9OzxYfo3brQavLSq4aemux8D60t4N+TrA/Vs/2aMgk2y80N+zhwP4gsLGC91+GRo8Hruv0cCsMfr8KcYkoFApqVC1Py+oOfNTQiSYda8svRoV4geUrGNFoNCxatIivvvqKGjVq0LVrVzp37pzvGS6EEEIIUUqMrSLkexatmIR7BF78mRvhp1CgwNzcMKPmldvH0Ooycj3nJSdPujT9gMa1evHfaDMG/QFJOtM0h+INH7IHITodrNsBR84avielwPJN0MATVTkbPOKiqGmvxt3VnlYdq9O1VXXK21vn8+aFEGVdvoKRb7/9lpSUFI4dO8aBAwfYuHEjy5cv56WXXqJLly507tyZpk2bFndZhRBCCFFQoX8FI7oqndl++TD3o0OoZGWJi5UVluaW6PRatLpMMjJS+P3mfv4MPYxer8szSwtzK9r6vEPtqq0pb+eKg20l0hRqtkfD9KuwM9sSIk7JiahOX+J+7ZrgnK3bVUIyBF2AI2con5RIy/a1aOHjRh0PJ6q62pOe9IhyGgvq1pVFlYX4O8v3mBErKyu6dOlCly5d0Ov1nD17lkWLFrF27Vp++OEH43zgQgghhCgDtBkQ9AVc/wUAvUrDrNNbeHB7NwCXCpGlytyStj7vUNd7CMfTHdmUDuHRcOc+HImHlCfjl5MXifx+O6Slg2IPeNcE95eweBRJR8sMerbyoPM7/ajt4ZSjq9Xly3GFKKEQ4kWT72AE4Nq1awQGBhIUFMSpU6dITEykfPnyMpuWEEIIUZZEXYHd78DDM8Zdf1i6GQORZ7GzcaZFvf+jRd3/w8bKnozMNNIyUjmd6cw3UVb8ellP3u0mQFwi7DgCB04ad3nVqED3Jk50a1WZ1o1bYalWPSUDIcQ/Rb6CkTFjxhAUFER0dDQWFhY0btyYDz/8kFatWsm4ESGEEKIUxSY+4NDZtdx+eIEK5arSMuMhVa//iOLxuiJ6hZJg6xpsSEwHhQKtQsUN99FUsLIhMi2F6LQ09AozdApzFAozGji74+DWhlC1OQ/S4FRYKsGRSm7oy5FimbUqeS4DxpNS4MxlOHkRrobiYGtBl+716NbaMM7DzaVcyT0UIcQLI1/ByM6dOwGoX78+gwcPpnXr1lhby+AxIYQQorQ8jL7F/jPfcPLPbWh1GdjrM+l2ZyvupBjTRGDOD1QkJEULCgXpSht21VrB8ua+vPJ4+Mb+WPjwFtxMNXw/B2Cy7oclqC0xEZcIx89DSDjExENsAor4RJp7vUS3jtXpPqUDTb1dZVVzIcQz5SsY+fnnnzl+/DjHjh3j008/BcDHx4eWLVvSqlUr6tevj1Ip/+AIIYQQxSU5NZ6Q+2e5HHqUK7ePQPRVKpBBGzJw0mfSjASss3WeOoYdWxSOpCsM/z8nmzvya+3vcHaqRx+Hv/LtaKfjG8KZeCedk67uYGaWewFS0+BmGFYnL+AR+ZBqLnbUqu9I7Wo1qO3hhFdNZxzKWRXjExBC/B3lKxjx8vLCy8uLDz74gKSkJIKDgzlx4gR79uxh2bJl2NracvLkyWdnJIQQQogc0jKSuRl+mut3g3gUG4qFuSVqCw1qlTXR8eHEPziNU/xNPPSpNCGdl0nHAn2ueaWqbNnn0JSbamfqWDlgbVmO/yW7sMuuH0nqSix0A71Ox+Ezd/j5tz/Zsu8y9x4lGE62sYKKjqCxBltrlNZqPDVmdHSzobdPRZr3c8VhSPUSfDJCiL+7Ag1gBzA3N8fc3BylUklmZiZ6vV5aRYQQQoinSM9M5Wb4aa7ePs6Vu8d5GH0LlbklapU1FuaWRMTdQafNwAYdjmRQgQxsyKSCPoPWpFCB3BcYzKHWa1h28qePtZNxV2AC/PcPw3ZFfQZHvt7LmH2XeRSVlON0ZUoqrRyUtG/mQrum7vg2cMPaSlY0F0IUn3wFIzdv3uTo0aMcPXqU06dPk56ejqurK506dWL69Ok0adKkuMsphBBCvFCSU+O5eCuA8zd+40rIYWy1STiTQQ3SaarPRJ2uxwIdanQ4kIkTmSbdrJ5GZ1sFZcVGUL4OlKtm+Dh4gl1lY5r45HS+uZbI4jgrUBm6Tz1ct5dvDp82ycvcXEmnFtV4rWtdXulUmwrlbYruIQghxDPkKxjp1asXAHXr1mXo0KF07twZT0/PYi2YEEII8SLS6/XsOLGQfadXodNlUkefzFT9I8qhLVx+CjOo2ARF1c5QuT1UbIzS0sE0jR7+jM9g+/FwAq7FcD4mgyjP6uBQHrJm0I1NMAw6ByxUZnRtVZ3XutXl5Q6eMtZDCFFq8hWM/Oc//6Fz5864uLgUd3mEEEKIF9qlkEPsPfk1ALX0yQzVP0CVx/gOE5qXoFx1sK8O5TwMf9pXR1G+Dqjtcj0lLT2TeUfDmZ9qR5yDAyhcwdM1Z8KYeCzWbKN3h5r8X9c69G5fCzuNZc50QghRwvIVjLzzzjvFXQ4hhBDihafVZbLt6BwAqulTGaaIRKV/HIhUbAJubcGhliHYUJcDlY3hY+0MqvxNma/T6Thy+jb++2+y1aEyGT6ekFvDhl5PpYcP6JQWw+uVzOm49g00NuoiulMhhCgaBR7ALoQQQojcnfhjMw+ib+KmT+MjHqLSPR547t4NXvkfmBcuGMjI0HLyj3C2Blxh7R9RRDaoB607gPlf0/Aq70dQKzGGppVs6OxZng4uVlRWVwIqFcGdCSFE8ZBgRAghhCgCKWkJ7AxchKVeyzD9fSyzxoi4tYWXtxQ4EHkUlcim3ZfYe+wGB69EklyvJrRtBK1Mu0xbpKUxUBmDX28nbNQViup2hBCiREgwIoQQQhTC5dtHuRl+hmqVGlDDrRn7Tq0kMSWaPvrYvwaruzSDf+3IdxesjAwtm4/c5NuDNzlyMxZd+XLQ1BfecYcnptG31mUypCJMrabGwVzGdAohXkwSjAghhBAFoNPr2BW4mD3By437zJQq9Oix12fSgTjDTqU59FwPFrZPzU+rhx//jGbpxVjOqcuhda4FPWvlmd5breUTNzPedDLHOo/F0oUQ4kXx1GAkLi6OLVu28ODBA+rUqUPv3r0xNzc95e7du6xevZpp06YVZzmFEEKIUpeansgPe8Zy4eZ+k/1aXQYAvfXRf62MXv9DcKhper4ODsfBvofpnHyYwrUUPREWVugsy0Pl8nlet4qFnv5OCt5wgoY2ZigURXtfQghRWvIMRiIiInj99dd58OCBcd/q1avx9/fHzc3NuO/Ro0ds2rRJghEhhBB/azEJ9/l660DuR10HQIGCDo3+TUpaPJdvH8Mm4TbNSTAktrAD3ykAhKTC2puJbHmYyZ8qDVozc8ACVBZ/rQGSTbmoKBqUM6eZmy1VrZQ00kBzjQKlBCBCiL+hPIORRYsWodVq+fHHH/H09GTPnj189dVXDBgwgPXr1+Pqmss85kIIIcTfkE6vY+2eMcZAxNLChve6L8C7eifAsNBh5uYOKMLCAHjYcCIzwxz45X4qD1SWgAbyWtYjNgHbyCi622YypWUlvFo6lsAdCSFE2ZBnMBIYGMhHH31E48aNAXjttdeoX78+AwYMYOjQoWzcuBFb26f3gxVCCCH+DoIu/pcbYScBKGdTkRH/9z2VHDzgwWkIP4rizkFUYYcBSLByxUP3McmR5qB64r/ZhCQUl27gHhtFywpqunuWp3NTN1wquJfwHQkhRNmQZzASExND5cqVTfbVqlWL5cuX8/777/PJJ5/w7bffFnsBhRBCvAC06fDwLMTdBNc2YFeltEtUZOKTIth6dC4ACr2efzd4g0rnl8C1zZD8KEf6kS99QbK5jeGLTg+h4TiFhfNqRXP61ylPiw/rYGNtUZK3IIQQZVaewYibmxtnzpyhVatWJvubNGnCf/7zH6ZNm8b06dN5+eWXi72QQgghyqgLq+DyT/AgGDJTDfscPOH9S6D8e0z19N+DM0hJi6eiPp1/KxNwO/pJrukSFDb8VOFt1lUYAIDy2FleT7rPyFe8afl2MxQy6lwIIXLIMxh5+eWXWbp0KWq1mi5duuDh4WE81r9/f27evMm6deu4cOFCiRRUCCFEGXMvCPZ9kHN/zFWIuQ6OtUu+TEVIq8vk/PW9nLu+G/R63iIaN22S8Xi6QsV+uy785tCFo7Zt+N3GB63CHDK1tL7yOxverY6bS6NSvAMhhCj78gxG3nvvPW7evMnChQsJDw9nxowZJsc///xzANatW1fo3/YEBAQwduxYzp07Z9yn1+tZsWIFmzZtIiYmhkaNGvGf//yH6tWrG9Okp6fj5+fHzp07SU5Opk2bNnz++edUrFjRmCYuLo7Zs2dz8OBBdDodXbt2ZdKkSWg0GmOa+/fv88UXXxAUFIRarebVV19l1KhRWFhI87kQQjzTnWzT29q4gNoeoq8YvkecfyGDkUcxofx8aCb3o64Tl/gQnd6weGEtUqiuNwQidy3cmO42lS3l+xKjMp2O1zIlme/c0nmzrU+Jl10IIV5EeQYjFhYWzJkzh+HDh5OcnJxrms8//5yOHTuye/fuAl/47NmzjBs3Lsf+5cuXs2rVKsaOHYurqyv+/v68//777Nq1yzhgfurUqRw4cIAJEyZgbW3NggULGDp0KFu2bMHMzNAtYOTIkYSFhTFt2jRSU1OZN28ekZGRrFy5EjAENAMHDsTS0pJ58+Zx//59/Pz8SE1NZcqUKQW+HyGE+Me5d+Kv7dcDIPoqbO9r+P7oHNTuXzrlKiSdTsva3Z9y+2HOFv+OZjrINGzPv/MvVl+uBL5J4GwJYQ/wIpWPW1TineYOWJnlb7V1IYQQ+ViBvUqVpw9C9PX1xdfXN98XTE9PZ+3atSxevBhra2syMjKMxxITE1m9ejUjRozg3XffBQxjVDp06MDPP//Mv//9b+7cucO2bduYP38+PXv2BKB27dp0796dgIAAunbtSlBQEMHBwWzevBkfH8Nvp1xcXHj//fe5dOkS9erV49dff+XOnTsEBATg4uICgFqtZtq0aQwfPhwnJ6d835MQQvzj6HVwL9CwrbaH8rXBPNtL+KNzuZ5WpHSZEH4MytcBm4rPTv8Mx//YZAxEVGZqnOyr4mjnSka6GV53Db/IuoUry3eWA/0pOHiKN3rUY8bIDtSq5vG0rIUQQuRBWdIXPHLkCKtWrWL8+PG88847Jsd+//13kpOT6dSpk3FfuXLlaNasGUePHgUgKCgIgPbt2xvTuLu7U7NmTWOawMBAHB0djYEIQPPmzdFoNMY0J06coG7dusZABKBz585kZmYSGBhYtDcthBB/N9FXIC3WsP2SLyiUYFfVEJgAPDoPen3xliFwOmzuAD82hYzcW/BzSI2Fs4thU3s4PN4Q0AAJyVFsP+5nTPbBK6v4/N1d1K8/l1pxIcb9c35vTabeDN8GbgRuGMTGBa9Tq5r88koIIQrrmS0jRc3b25uAgADs7OxYunSpybHQ0FCAHFMKu7m5ceDAAQBCQkJwcnLC2to6R5qs80NCQnK06CiVSlxdXY1pQkNDcXd3N0nj4OCARqMxpimoGzduoFSWeHz3VCkpKQBcvny5lEsi8kvqrOyTOgL7u79Q6fH2I1VNoh4/iyo2tbBJOwkpEVw/f5hMy+dvsciNQptOjTNLDf+JJdzl7vHvSKzYKY+0aZg9PEX5h7vQ7dmDUvd41q+ww8SF/8k9n9kEXFpGSlo8ABb2bflovxUXw49QtUIEJ5N/A+Cu3pmAMB8WjG1MN183FIrEf/TPQHGTv2dln9TRi6c06kyn0z31eIkHI9kHmT8pMTERCwuLHAPIbWxsSExMBCApKQkbG5sc59rY2PDgwYNnpsnKJzEx8ZlphBBC5M4q+qxxO8WhoXE71a4ONtGGxQEt46+QWEzBiCbiCOYZccbvtg8CTIIRZUYC5UPXYx0ViFXsBZS69FzzKXd/J4lpUVyNeQQKBelKG35wn0kVbQzdnEL56MFyY9rjir5sWdQHC9XfY8piIYQoC0o8GHkavV6f58xcWfvzSpN9v16vz7WF4sn9eeVT2NaNGjVqoFarC3VuccmKfOvUqVPKJRH5JXVW9kkdAYF/Gv5UmFG12Wtg8XimQl1HCF0LQGV1JDzvM0qJMqxlUrkDvNTir/1XJ5kks486gr1nTVA+/m9t7yC4/l2O7DLMrDlr8RJ3UmPpq4/EDHCNDmIwNsTqzbBXwaLzNbHWpZicl6CuSP8PFoDK6vnuR+Sb/D0r+6SOXjylUWdpaWlcvHgxz+NlKhixtbUlPT2djIwMVCqVcX9SUpJxJi2NRkNSUlKOc5OTk03SRERE5Joma2rfp+WTffpfIYQQT0iOhJhrhu0KPn8FIgDOf7WS8Oj881/r8Fi49D0oVfDueXCsa7h+yE7TdKnRhsHsldtDcgT6P9eT9eumGEs3dmracciuHdGxJ3kp9iAoyhGPGe/rH2IG+PD4/4PHXbWy0yvM0LSfK4GIEEIUg3wHI7t372bfvn0kJSXl6PulUChYtWrVcxematWq6PV6wsLCqFatmnF/9u/u7u5ERkaSmpqKpaWlSZrGjRsb05w9e9Ykb51OR3h4OH369DGmCQsLM0kTExNDYmKiybWFEEI84X62ST5eaml6rHxtMFODNu35Z9TS6+HW46BDlwEBH8HrB+DKBuPAc2yrQMIdw/aNbYZg5I/VKB53yzqMHSuVdTnqPAyP6N/wjj0IQKZCjb/bp9xOOMzUmP9ixl+D7fW2lVE4N4KKjaFiIxQuTcHa+fnuRQghRK7y1R9p1apVjB49mv3793Pt2jVu3ryZ41MUGjZsiFqtZv/+vxbSiouL4+TJk8bpg319fdFqtcYB7WAYjH79+nWTNBERESarwwcHB5OYmGhM06JFCy5evGgcZwKwf/9+VCoVTZs2LZL7EUKIv6Xs64u4tjI9ZqYCJy/DdtwtSIuj0GKuQ0q2Vu67h+DKT/DnD3/t6/otKB6P4bixDXSZaM8vMx4+rChH+dSbvHLlPbwf/QiATq9g78N/c+ZAFb461o85dt/xoOkc6Lsbhj1EMfQOvLoNfCeDRy8JRIQQohjlq2Vk06ZNdOnSBT8/v2IdE2FjY8M777zD4sWLUSqVuLu7s2LFCjQaDa+//jpgWPeke/fuTJ48mcTEROzs7FiwYAGenp507twZMAQaPj4+jBgxgvHjx5OZmcncuXNp3749Xl6G/yR79+6Nv78/gwcP5pNPPuHRo0d89dVX9OvXjwoVKhTbPQohxAsv/Phf20+2jABUaAAPzxi2I34Ht7aGbb0e8hgXmPt1juXcFzDirymFHetB1c6G/O8ehPjbEPQlZonhAFzBirvmjqi1CSZZHDrSjDvXkxjxppIpw7tToXzOyUyEEEKUjHwFI48ePWLmzJklMjj7008/RalU8t1335GcnEzDhg2ZM2eOcTwIwOzZs5k9ezZ+fn7odDpatmzJ559/blx9XaFQ4O/vz8yZM5k8eTIWFhZ06tSJzz77zJiHlZUVa9asYcaMGYwdOxZbW1vefPNNPv3002K/RyGEeGFp0+HhKcO2xhVsK+dMYzJu5JwhWPh9BRwYCdVfgT6bDeuSPEv2YCSrO1ZWIAJQ7z1DcFPjVUMwAuiDZhjHihxSOhDWcgdO/1uMhdVO1Op0gk41QKltyYmfXqG5j1tB7lwIIUQxyFcwUrVqVR49elTkFx85ciQjR440LZC5OWPHjmXs2LF5nmdtbc3MmTOZOXNmnmkcHR1ZtGjRU69ftWpVVq9eXaAyCyHEP9qj85D5eJ2Ol1rm3tLh3MA0/cNzhkBElwnXf4E/voX6Q599rXuGYESHkjstZuJ+8IO/rq1QQp23Dds1XoGDnxh26w1jGqMxZ7vDv4j88TR79lijVPwfVlbpjHm/G59/0AYLizI1f4sQQvxj5WvMyODBg/H3988x4FsIIcQ/zNPGi2Sp4ANZ7RP3g2HPu38NOAc4OhGSc854aCL5kWHMCBCGigUHviS+3uC/jlftApqXDNt2VU1bY4BjCjtupHbk9B7DIHpzc3Nmj+zE9JEdJBARQogyJF//Iu/bt4/Y2Fi6dOmCi4sLVlam0xsqFAp27tyZx9lCCCFeaHo9PDoLVzaaDh7PbbwIGKb6dahpmP43OpdVflNj4Mh46L4m72tmG5dyE0t0ei3fRT7kkxp9UUT9AW3mmqav8apx9q4MYIdVQ67/ZJhly97OkqUTWtK4jowHFEKIsiZfwUh8fDy1atUq7rIIIYQoazKSYHNHeHDSdL+lw+MWkDxUaPDXWiRgWIywzy+w623ISDSsHeI1ENzaQEYKxFwF+xp/rVmSbbzITYVhGvcb989yqMt8OrzyCjo9bIyA7x6BTv//7d15nI3l/8fx1zmz78zYlzFjmbGPkV1kD6kQCemLvkSkQlGSSoVvEqVQ0aZfJUS7iIqMJTvZGcvYxmxmnzlz7t8fhzMm1KlmOTPez8fD93vf13Xd9/nc58rymftaoLG5FzN4DhcMtuPLr0mdIDaRKhX8+W7BQFxy4vPn+xARkXzlUDLy0UcfFXQcIiLijI5/nzcRMZmhagdo8Qy4uF/TPCcnGxcXN9uwqUNLciuaPwM174LWL8BPlxcK+X6wbYjVmY22fUmC6sHAzeDmkycZOUbunlL/9/N0zgd24LWLfmxJsZWVSf0d9zMLeM9UnmAjg5WuwRz70sTYwS15ZkRbSgd4sX+/khEREWekgbMiInJjcb/nHjd+FJo9BT7lr2kWmxjNlxteZdeRH7glvAf/qds9t7L8LdD88mqGkY/Avg9sS/4mHbP9sn/WPoh6AVo+i3F+OyYgFldOeYaS5BlKcNIveGTFMvfnNzhQ/n7qXNpM9YQfCLm8keFOkw87TT5Em7uz+4P/UiskqAC+EBERyU83TEYiIiL44IMPaNSoEQ0bNsT0J2vDm0wmdu7cWRDxiYhIUbp6zke9wdckIslpcXy36Q027PkU6+VJ6lsPrOTuW5+gVKPRkHQUOr5p2wwRbMO1Os2DT9uAkWMr861km9BuzYZts8C3MibDdq+jeHEsqAfPt76HZUu74WJk0+jcIhqdW3RNqBb8qFB9EHN6PGpf6l1ERJzbDZOR7t27ExgYaD/+s2RERERKqPgDlw9MUDrv3MHktDhe+rAbKenXDoGKPreLRh3fuP49K7WE/httb10qtoDAcPj1Gdj8sm3VrZ9y93s6avIkqNLtvDtrK9FJ9WhSf+c1t3M1l6JL02F0bDoIDzfvf/qkIiJSBG6YjEybNs1+PH369EIJRkREnIhhzU1G/KvBH/6hf+jUJnsi4ubiQa2qzfk9+hcAos/upFGt229874rNbL+uaD4JDnwCScdz35gA2zzr8M28PVh3HMTVtTYVAs9SoVwcnq7VaRzehhYN2hFasTFurgW/Ka+IiOQ/zRkREZHrSz4FlnTbcVCda6pjE6Ptx/07v0StKs2Z/G4bAI6f2/n3PsvNGzq+Bcu72YtSMPOzXy+su2z7jfj5+NKm7iuMGtAUTw+3v3d/ERFxSg5teigiIjehuKvmiwTWvqb6QsJx+3GFwJqU9qtIKV/bnJKT5/eQk5P99z4vtCtGWF/76VE8OXw0BKxWHu7flGM/PMq4Ia2UiIiIlCBKRkRE5Prs80WAwGvfjFy46s1I2VLVAAip0AiAbEsGZy4e/NsfeSC0Lxcvv7T/0juS5A1neOGR9syd3J1S/l5/cbWIiBQ3GqYlIiLXF/9Xb0aiAfDzLoOXhx8AIRUj2XlkFWAbqlW1fH2HPy4lPYnX1r6Kr6kqrhh85fYfZg6sx7ghN9jpXUREij29GRERkev7kzcjKekJpGUkAlCudKi9PLRiI/tx9NmdDn9UthX+++lk3HMukmUycyigNS3L3KZERESkhPtbb0aOHTtGamoqhmFcU9ewYcN8C0pERJzAlTkjnkHgXSZP1dWT18uVDrEfVy1XD7PZFavVwvE/SUYOnozi6MVo/Cu1IdWjCv9b/y11Er8FINvsjclnBIt6ht3wehERKRkcSkaOHj3Ko48+ytGjR6+pMwwDk8nE/v37r3OliIgUS+lxkB5rO77OSlpXhmgBHDSHcDYLKrqDu5sXlcvU5tSFvcQmRpOSnoCvV+k813634//45qdn7efnfRpQLeus/TzRbSDL+7XO3+cRERGn5FAyMn36dM6fP8/IkSOpXLkyZrNGd4mIlGh5hmj9+Upai9NDmb4NBpSBcZVsQ7VOXdgLwIlzu6gX2s7edsOez/IkIgDlU/fYj1Osdfi/h8Zro10RkZuEQ8nIb7/9xtNPP03fvn3/urGIiBR/f7GS1tXDtJI8Q8g24INY26+HXRphYjEAx8/utCcjm/Yt49M1z9ivO12qPT6JRyjNKQByrB5M+89cXFxc8v1xRETEOTmUjLi5uVGhQoWCjkVERJyFg3uMGJhI8gzG3QRZl6cTLs6JZNDldtFndwDw655P+WTNZMDWaE/5+9m1pi5JUZUpXSqRW5vl8PqE0VQsU62gnkhERJyQQ+Ot2rRpw7p16wo6FhERcRYJV70Z+cOcEcMwuJB4AoAU94rkmD051hgeKGurv+QRjIuHbZ5I9LldfL7uBT5Z8wxXEpG95fqz40gnkqJ+B6B65Tp89OIrhFQKL9hnEhERp+PQm5G7776bJ598kvT0dJo0aYKX17UbT3Xv3j3fgxMRkSJy5c2Iqyf4BeepSkq9QFZ2GgCJnqHU9ITKHvBYRfgwFjCZSPRrhF/mOjKyUvh554f2a/eUG8BOYyjJn34AQP1a5Vj1ziAC/DwL5bFERMS5OJSMDB8+HIAvvviCL7744pp6k8mkZEREpKSwZEDS5QnqpcPBnHcOx9WT1xM9Q2jkYztu5APB7nAyC/Z7RtKM3DfqVlxYX+0ZDgf0IXPC62AYVKngzw/vDiKotHeBP5KIiDgnh5KRDz/88K8biYhIyZBwiCtDqq43X+TqyeuJniF0uZyMmExwdyC8cQ5O+zWl2eU2JvdSfFn9DWICWsLXv0BqOl6erqycex8Vy/kV6KOIiIhzcygZadas2V83EhGRkuEvVtK6eo+RJK9QGl31YqNnkC0ZOevXhORaj9HR7RQveY8ixuXyUK/12wH4YFovGterVBDRi4hIMeLwDuznz5/njTfeYOPGjSQnJ1O6dGlatGjByJEjqVixYkHGKCIihekvVtL645uRK8O0ANr4QSkXSMwxsazMaO6sCYcOXa7cewQuJvLsw7fRt2u9goldRESKFYdW0zp37hz33HMPK1asoFKlStx6662UKVOGZcuW0adPH86fP1/QcYqISGGJz7uS1m8Hv2bd9vfJyckGcueM5JhccfeuTCX33OZuZugRaDtOtcLDR625lb9s454udZgy6raCfgIRESkmHHoz8tprrwGwYsUKatasaS8/cuQIQ4YM4fXXX+ell14qmAhFRKTwpMfBidW2Y5OZ6PQ03v/2MQDOxB+nf4dniU08CcAlj6pE+Lnxx83S7y4Ni2Ntx7E5l3/mlZRCw/REPpg2BLPZoZ+DiYjITcChvxHWr1/PqFGj8iQiADVr1mTkyJH88ssvBRKciIgUsl8mQEac7bhWb74//pu9KmrPx2ze/wU5VtsbkqQ/DNG64vbS4GEy8pR5b9vLV2/0w8fb/doLRETkpuVQMpKenk6VKlWuW1elShUSExPzMyYRESkKp9fD3oW2YzcfuG0Wx87tytPksx+ftR//cb7IFYcPnMHjyMk8Ze91DSa4Uqn8jlhERIo5h5KRatWqERUVdd26qKgoKlXSiigiIsVaThasGZl73uoFDL8qpF7Mm4xYcrLsx39MRtIzspkwczXN+r3DpQ2519XLSubeJvp7QkREruVQMtK3b18+/PBD3n77bWJjbQOBY2Njefvtt/noo4+4++67CzRIEREpYL/Ngrh9tuOyEdB4DHGXTmPKigcgwTOUHJNbnkvSvEIJ97IdH46Oo8V97/K/hb+Sk2PA1n24xSXggZUFjbWXiIiIXJ9DE9jvu+8+oqKimDVrFq+99homkwnDMDAMg/bt29t3aBcRkWIo+TRseuHyiQk6LwCzK9FXDdE6Fng72WZvWpyeZS+rWDoEVxOsWLOf/zy1gkspmQC4upp5anBzJnT2xexmxivvBu4iIiJ2DiUjLi4uzJ07l40bN7Jx40aSkpIoVaoULVu2pFWrVgUdo4iIFKT9H4Ml3XYc8RBUbA7AkTM77U3i/SI4HNCe0ITVlE/dQ6JHNeoEluepWWuY/s4Ge7uawYF8Prsvjepo/ykREflrDm96CNCqVSslHyIiJc3hZbnHkY/aDw+d3W0/vqVKI8w5rqys8xFhF7/itH8LWm07ysKrEpGeHWvz/rSeBPh5FkrYIiJS/N0wGXnuued48MEHqVq1Ks8999yf3sRkMjFlypT8jk1ERArapZNwbqvtOKguBNl2XM/JyebiRdsckmT3SoSXLks7N3jomC/7yvcH4LuPF9pvM2NcJ554sDWmP246IiIi8idumIx8+umn3HXXXVStWpVPP/30T2+iZEREpJg6vDz3uNY99sOYiwex5tjmgJz3bUhXT+gZCJNOwkULYLXC6fMAvPRYB578762FGbWIiJQQN0xGDhw4cN1jEREpQfIkI73th9HndtqPz/s2IswLvFxgSkAyjx7OwfrLDsjI4j89I3hqeJtCDFhEREqSvzVnRERESpDUcxBzec5HQHXbkr6XRZ/NXUnrvE8EYV6QlWVh0VMfY91/DoDbmlbj7efv1NAsERH5x/50zoijNExLRKQYOrICMGzHte6Bq5KKK8v6WnHBpVR9/FzgmTd+ZsflRKRGcGmWzemHu7t+piUiIv/cn84ZcZSSERGRYujQVatoheXOF0nLuMSFhGMAxHmHUdPXi007TzHt8spZLi4m/u+Vewgq7V2o4YqISMnj0JwREREpYdLj4NQ627FvZajQ1F514nzukr7nfRtR3S2HB8Z/gdVqe4vy9PA2NGtYpVDDFRGRkknv10VEbkZHvwQjx3ZcqzeYzPaqE1ftvH7BpyGWqIMcPhEPQOO6FXlmRNtCDVVEREouzRkREbkZHf4i9/iqJX0Nw+DgyY328/O+Eez/5DcAPNxd+GhGL80TERGRfKM5IyIiNxvDgDOXEw6PUlA5d4+QX3Z9xOHTmwFIcw0iwasGnPsegJcf70jdmuUKO1oRESnBNGdERORmk3oOMuJsx+UagdkFsK2gtfznafZm60OetY3kikukaYNKPDqoReHHKiIiJZr5r5uIiEiJcjF3gjplGgKQkp7Awq8fIceaDcDe8oM4EnQHxCbggsE7L9yFi4v+yhARkfx1wzcjw4YNY+LEidSoUYNhw4b96U1MJhNvv/12vgcnIiIF4ELuBHXKNsRqWPlo1RMkJJ8BoHzZBswLnmirPx/H+CGtiKhdoQgCFRGRku6GycjRo0fJyMiwH/+Z/N59Nycnh0WLFrFkyRIuXrxIzZo1GTt2LC1btgRsEyznz5/PZ599RkJCAo0bN+aZZ56hRo0a9ntkZWUxc+ZMvvnmG9LS0mjTpg2TJk2ifPny9jZJSUlMmzaNdevWYbVa6dKlC0899RS+vr75+jwiIk7l6jcjZRuy+8hq9h3/CQBvjwDOeYzFavYAICA1hWdH31YEQYqIyM3ghsnI2rVrr3tcGBYuXMjs2bMZM2YMDRs2ZNmyZQwbNowlS5ZQt25d3nzzTd5++23Gjx9P5cqVmTdvHoMHD+bbb7/Fz88PgClTprB27VomTJiAt7c3s2bNYvjw4SxfvhwXF9v46EceeYTTp0/z3HPPkZGRwf/+9z8uXrzIggULCvV5RUQKVeyVZMQEQfX4ZcNwe1XXppPoviQTetnOh7SqireXe+HHKCIiNwWnXJ/xiy++oEePHowYMQKA5s2bs23bNpYuXcrYsWNZuHAho0eP5oEHHgCgSZMmtG/fnqVLlzJkyBBOnjzJihUrePXVV+nevTsAtWvXpmvXrvz444906dKFTZs2sXnzZpYsWUJERAQAFSpUYPDgwezbt4969eoVzcOLiBSknCyI3287Ll2Ls0mnOXRqEwBlAqoyd4lBZoXcFbN61dfqWSIiUnAcSkZSUlKYM2cO27ZtIykp6Zp6k8nEmjVr8i2orKysPEOlXFxc8PPzIykpiV27dpGWlkbHjh3t9QEBATRr1oz169czZMgQNm2y/cXarl07e5uQkBBq1arF+vXr6dKlC1FRUQQFBdkTEbAlPb6+vqxfv17JiIiUTPEHwGqxHZeN4Jddi+1Vq/z7s6nXPXmah3kVZnAiInKzcSgZmTJlCt988w1169YlJCQk3+eI/NHAgQN588036dy5M/Xr12f58uUcPnyYxx57jOjoaACqVq2a55oqVarYh5MdP36cMmXK4O3tfU2bK9cfP36c4ODgPPVms5nKlSvb2/xdR44cwWx2rtVm0tPTAdi/f38RRyKOUp85v+LcR/4x31H58vHZnCCi9i0HINvsyY5y9+ZpW82cSfyRYyQU7B/5haI499nNSn3m/NRHxU9R9JnVav3TeoeSkQ0bNvDQQw/x+OOP50tQf6V///5s2rSJwYMH28see+wxOnbsyIIFC3B3d8fdPe8YZh8fH1JSUgBITU3Fx8fnmvv6+Phw7ty5v2xz5T4iIiWN56WD9uPDWWlYcmwLlRwOupNM11JwLIbSGSkMiCxNT49LFPDPnkRE5Cbn8JyRW265pSDjsDMMgwcffJCjR48yZcoUatSowcaNG3nzzTfx9/fHMIwbvpm5Un6jNleXG4Zx3bcYNyp3RM2aNfHw8PhH1xaUK5lvnTp1ijgScZT6zPkV6z7aF2M/3JGcu1LinvL3w8lzuMxYyC/LHqJ+WDmg5MwXKdZ9dpNSnzk/9VHxUxR9lpmZyd69e29Y71Ay0rVrV77//nvatm2bb4HdyLZt29i2bRuzZ8+mW7dugG0uR05ODq+88gqPP/44WVlZZGdn4+bmZr8uNTXVvpKWr68vqamp19w7LS0tT5vY2NjrttHSviJSYl1e1jfH1ZvDSWfBZOKM7y1c9KkHy79m/OCW1A8r/xc3ERERyR8OJSMTJkygX79+DBgwgMjISLy88s5oNJlMjBo1Kl8CujKMqlGjRnnKb7nlFt555x1MJhOGYXD69GlCQ0Pt9Vefh4SEcPHiRTIyMvD09MzT5sobnpCQELZv357nM6xWKzExMdx555358iwiIk4l7QKk2v6MjXX1B6vtTfGeCoMgI4vgkyd5dtZ/izJCERG5yTg0Hmnp0qUcPnyY7du3s3DhQubOnXvNr/wSEhICcE2isGvXLlxdXenSpQseHh55Vu9KSkpiy5Yt9k0RW7ZsSU5OTp79UaKjozl8+HCeNrGxsezenbv51+bNm0lJSbG3EREpUWL32A+PZWcDkOESwLHSXWDLHuY92Ul7ioiISKFy6M3IokWLaNWqFePHj6dcuYIdQ1y/fn3atWvH888/T2JiIjVq1GDLli28++67PPDAA1SoUIH777+fOXPmYDabCQkJYf78+fj6+tK3b18AgoOD6dq1K5MnTyYlJQV/f39mzZpFeHg4nTp1AqBFixZEREQwevRonnzySSwWCzNmzKBdu3bUr1+/QJ9RRKRIXLXz+kmrCUxwzi8Sq9mdDpnxdL+tcOYGioiIXOFQMpKQkMDQoUOpW7duQccDwJw5c5g9ezbz588nKSmJatWqMWnSJO677z4Axo4di9lsZtGiRaSlpREZGcn06dPt80EApk2bxrRp05g5cyZWq5VWrVoxadIk++7rJpOJefPmMXXqVCZPnoy7uzsdO3bk6aefLpRnFBEpdLG77Icx2BbbuODTEPOpc3w4onlRRSUiIjcxh5KROnXqcOrUqYKOxc7T05OJEycyceLE69a7uroyfvx4xo8ff8N7eHt7M3XqVKZOnXrDNkFBQcyePfvfhisiUjzE5r4ZOYNtONZ53wj6ZqdTuXyFoopKRERuYg4lI+PHj2fs2LF4eHhwyy234OPjc83SuUFBQQUSoIiI5AOrBeL2AXDe8CTz8hLmse51mN+pTFFGJiIiNzGHkpHRo0eTmprKpEmTbthGu2+KiDixhEOQkwXAWZPtj/4kj2AmhwZQyv2f7a0kIiLybzmUjAwcOPCGGw2KiIjzi9+3isDLx2ew7dFkLtWAidWda6NWERG5uTiUjDzyyCMFHYeIiBSQsxeSubBmDoEBtvPfTd4A9A2LRD9nEhGRoqR38yIiJdiFuBQeemQaEQEnAIh2CST68kpadSs1LMrQRERElIyIiJRUcQlpdBr6Ie29cjeA/dUcBCYTZrMrVcoVznLtIiIiN6JkRESkpLDmwIZJsO4xjIxE+j6+hANHzjKotm0VrWyTK3sstknslcuE4+7qWZTRioiIODZnREREioHfP4TNLwNwdv8m1m/pzN0hBynjlgLAat9WpKTGABBSIaLIwhQREbnCoTcjb7zxBocOHSroWERE5N/Yv9h+WCl9M/Nv/ZoHmx+xl/3mU8d+XE3JiIiIOAGHkpF3332XkydPFnQsIiLyT6WcwTi5Lk/Rg+E76ea7A4AYt0qY3bPtddUqaPK6iIgUPYeSkeDgYC5evFjQsYiIyD+UvO8zTBgAbPFpek39+qoPkBK3BwBPdx/Kl65eqPGJiIhcj0NzRgYNGsS0adPYu3cvYWFhlClT5po23bt3z/fgRETkrxkGnN/zf/hdPn+w7Bx6lV7NC6en2NvUqN+dDdGfAxBcviFms0sRRCoiIpKXQ8nIs88+C8DSpUuvW28ymZSMiIgUkW+PHeKOpN8A2ONZj72v/IqlQRi3dnuELsffYFeN4WCJt7fXEC0REXEWDiUjH374YUHHISIi/8CFLNi3/f+44/L5qnPlCSu3m0UP30vLyPsgezoRbt68/91Y+zW1qjQvmmBFRET+wKFkpFmzZgUdh4iI/APjow2eufB/9vNLpY/Quf0JXDy3A8Hg5o3VmsPv0b8A4O7qpWRERESchsObHmZkZLBo0SIGDx5Mt27dOHz4MAsXLmT79u0FGZ+IiNyAxYBjJ7YRlnEYgKN4Em9yA2Dj3iX2dsfP7iQtIxGA8OBWuLl6FHqsIiIi1+NQMpKYmEjfvn155ZVXOHfuHNHR0WRlZbF+/XqGDBnCrl27CjpOERH5g71pMPTki/bz30y+9uMjp7cQf8m2weG+47lL/tav3r7wAhQREfkLDiUjs2bNIjY2luXLl/P1119jGLblI+fOnUuNGjV48803CzRIERG5VlQy3Jn0PQA5wNrEUJrV6Wuv33rgSwD2Hf/JXlYvtF3hBSgiIvIXHEpGfvzxR8aMGUOdOnUwmUz2cl9fXx588EH27NlTYAGKiMj1HTi1l7JGJgBHc3y5tcl8bm8+3F6/df8KEpLPEHPxAABVytahlG+FIolVRETkehxKRpKTk6lSpcp16/z9/UlNTc3XoERE5K+5HF1uPz6YWZGBPRpRvnQo1SpEAHAu/ijfb55nb1MvVEO0RETEuTiUjISEhLBu3brr1kVFRRESEpKfMYmIyF84n2ElIvlX+7lnSGvMZtsf6U1r320v/3XPJ/ZjDdESERFn41AyMmDAAD799FNefPFFtm7dislkIiYmhvfff5/FixfTr1+/go5TRESu8urPJ7klba/9PLzVffbjW8LvwGzKu8O6r1dpQi6/MREREXEWDu0zct9993HixAk++OADPv74YwzD4NFHHwVsicrAgQMLNEgREcmVk2Plo11neNHlHAAJuFIhuK293s87iDohbfJMXK9TrS1ms8sfbyUiIlKkHEpGACZMmMCAAQOIiooiPj4ef39/WrRoQfXq1QsyPhER+YMl3++jmn8M7qlWAGLcg6jv5pWnTdM6PfMkI/WrdyjMEEVERBzicDICULVqVVxdXUlKSiIoKIiyZcsWVFwiInIdOTlWnp/3C737RcPltUNSS4Vf065h9Y54uPmQmZ2K2eRCnWptCjdQERERBzi8A/u3335L586d6dChA7169aJt27b07NmTTZs2FWR8IiJylU+/3cvBTDOt0zbay0yVWl7Tzt3Nix6tHsfDzYfOTR/C29O/MMMUERFxiENvRn744QfGjh1LjRo1GDVqFGXKlOHChQt8++23/Pe//+XDDz+kcePGBR2riMhNLSvLwrNvrIPq1Wmcvg+AbMA/tPN127dvPJh2kf/Jsz+UiIiIM3EoGZk/fz6tW7fmnXfesS8dCTB69GiGDh3K7Nmz+fDDDwssSBERgXeXbufYqQQqdPKgYk4SAKfxoFL5G6+SpUREREScmUPDtI4ePcrAgQPzJCIAZrOZ+++/Xzuwi4gUsNS0LF6Y9zMALcuftpfHuAXi71OmqMISERH5VxxKRsqWLcv58+evW5eSkkKpUqXyMyYREfmDOR9t4vzFVPDx4jbzFnt5aunaRRiViIjIv+NQMjJy5EjmzJnDjh078pQfP36cN954g1GjRhVIcCIiAvGJafxv4eXd1kMr0yp5Q27ldSavi4iIFBcOzRlZvXo1hmEwYMAAatasSYUKFYiPj+fgwYMYhsGiRYtYtGgRYBuf/M033xRo0CIiN5MZ7/5KUnImAE261KdB8iEAEnChTJVWRRmaiIjIv+JQMpKamkpYWJj9PCMjA29vbyIjIwssMBERgZjzl3h98WYA3NzMtAlPw3NrNgDH8aRK2TpFGZ6IiMi/4lAy8tFHHxV0HCIich0vvPUzGZkWAB66twmlk3bZ6066+NGoVLWiCk1ERORfc3jTQxERKVyHo+NYuGw7AD7ebjwxvC0VEn6z12eWroXZ7FJU4YmIiPxrSkZERJzU5NfXkpNjAPD4Ay1J8PGlQeo2e717haZFFZqIiEi+UDIiIuKEtu87w2ff2XZZDwzwYvzQVuxJNaibcRiAS7hQtmKTogxRRETkX1MyIiLihJ6e/WPu8UNtCPDz5OTFGPytaQCcwZ3g8g2KKjwREZF8oWRERMTJLP/hd1ZtOApA5fJ+PNzfNhwrLXavvc05kyeVyoRd93oREZHiwqHVtAAsFguXLl0iMDAQwzD49NNPOXXqFN26daNBA/10TkQkP2zbd4ZBE7+wnz83qh1enm4A+MRutpen+4fg6uJe6PGJiIjkJ4fejBw7dozOnTvz/vvvA/Daa6/x/PPPs2jRIvr378/WrVsLMkYRkZvC6XNJ3Dny/0hLt+0jck+XOgy9x7afU4IFaiVG2du6lm9cJDGKiIjkJ4eSkdmzZ2MymWjfvj05OTl89tln3H777WzZsoUWLVowd+7cgo5TRKRES07NpMfI/+NsbAqYTFQZ2p2Ix+8Bk+2P6T2pUD9tn719QHC7IopUREQk/ziUjGzZsoXHH3+cyMhIdu3aRVJSEvfeey/+/v7079+fvXv3/vVNRETkugzDYNCE5ew6cB6AoC5NOd26Gc+eceVtWxF7UnKonn0WgFhcqVq5WVGFKyIikm8cSkbS09MpW7YsABs3bsTNzY0mTWxLSrq7u2MYRsFFKCJSwr32QRQrfzwIgJ+POy0HtbfXzTkLhgHnY4/gTg4A50xelA+sUSSxioiI5CeHkpFKlSqxZ88eANasWUNkZCQeHh4ArF27lipVqhRchCIiJdimnaeY8Ooa+/kH03uxw/Cynx9IhzVJYJzdYC9L8a2qnddFRKREcCgZufPOO5kzZw7dunXjwIED9OnTB4DRo0fz6aef0q9fvwINUkSkJIpPTOO+cUuxWKwAPP6fFtRvXYeYrLztZp+BChd+sp+7lNUKhiIiUjI4tLTvww8/jJubG1u2bKF///7cddddAKSkpDB27FgGDhxYoEGKiJQ0hmEwZNJKTpxJAqBZw8pMH9uJ9+OvbfttIoxP3WU/967appCiFBERKVgOb3o4bNgw3nnnHR544AF72fvvv8+wYcMKJLCoqCj69u1Lw4YNad++Pa+//jo5Obbx0oZhMG/ePNq1a0dERARDhgzh6NGjea7Pysri5ZdfpnXr1kRGRjJmzBjOnz+fp01SUhITJ06kefPmNG3alEmTJpGSklIgzyMicrXFX+7my7W2eSKl/D359NU+uLu7su4SeGQncM++Pgzdfw9+mTEA1Mo8AYAFKF+9S1GFLSIikq/+1g7sq1atYtKkSTz44INER0ezYsUKTpw4ke9Bbdu2jWHDhlGjRg0WLFjAwIEDeeedd5g3bx4Ab775JvPmzWPo0KHMmjWL5ORkBg8eTHJysv0eU6ZMYeXKlYwbN45p06Zx4MABhg8fbk9oAB555BG2bNnCc889x9NPP83atWsZN25cvj+PiMjVsrIsPPvGOvv5u1PvIrRKaQwD1iVBy7NvM+XSd4xN/J77Dj2Et+USlayXALhg8qRM6ZpFFbqIiEi+cmiYVmZmJiNGjCAqKgovLy8yMjJITU1l2bJlTJs2jf/7v/+jRo38W9nl1VdfpXXr1kyfPh2Ali1bkpiYyObNmxk8eDALFy5k9OjR9rc0TZo0oX379ixdupQhQ4Zw8uRJVqxYwauvvkr37t0BqF27Nl27duXHH3+kS5cubNq0ic2bN7NkyRIiIiIAqFChAoMHD2bfvn3Uq1cv355HRORqC5ftIDomEYDbmlajd+c6gG2y+vlseOvCuzQgDYBnUlbjfXiE/SdHCV4VqWQyFUHUIiIi+c+hNyNz5sxhx44dzJ07l82bN9uX8p02bRoBAQH5uulhfHw827dv5957781TPn78eD766CN27dpFWloaHTt2tNcFBATQrFkz1q9fD8CmTZsAaNeunb1NSEgItWrVsreJiooiKCjInogANG/eHF9fX3sbEZH8lp6RzdR5P9vPX3qsI6bLycW6JAhKO0yn7OP2+mCyeCFxSe4NAmsXWqwiIiIFzaE3I99++y2jR4+mU6dOeYY5ValShREjRjBr1qx8C+jgwYMYhoG3tzcjRozg119/xdfXlwEDBjBq1Ciio6MBqFq1ap7rqlSpwtq1awE4fvw4ZcqUwdvb+5o2V64/fvw4wcHBeerNZjOVK1e2t/m7jhw5gtn8t0a+Fbj09HQA9u/fX8SRiKPUZ87v3/TRohUHbLusA20bVyTQK9V+n5UplRl6Zib+5OS55urzNI9a+m/jH9Dvq+JHfeb81EfFT1H0mdVq/dN6h5KRuLg4wsPDr1tXvnx5kpKS/n5kN5CQkADAk08+SY8ePRg8eDBbt25l3rx5eHh4YBgG7u7uuLu757nOx8fHPvk8NTUVHx+fa+7t4+PDuXPn/rKNJrGLSEFIScvm3S9y/wIYMyB3iV6rAVst3rwa/4W97HSlu6l0ZmWeV9ju5VoXRqgiIiKFwqFkpFKlSvz222+0aXPtcpK7du2iUqVK+RZQdnY2ALfeeisTJkwAoEWLFiQkJDBv3jyGDx9uH9LwR1fKDcO4bpuryw3DuO5bjBuVO6JmzZr2zSCdxZXMt06dOkUciThKfeb8/mkfvfDmTyQm2zYR6du1Lvfc0cpetycVQn7ZQP2cWAASzF5U7reMlE0v4xf1LAAZuNCwRR9MTvYGtjjQ76viR33m/NRHxU9R9FlmZiZ79+69Yb1Df6P16tWLRYsW8d5773HmzBnAtnTu6tWrWbRoEXfffXf+RAv2txV/THxatWpFWloa/v7+ZGVl2ZOWK1JTU/Hz8wPA19eX1NTUa+6dlpbmUBtfX998eRYRkSviEtKY+d5GAMxmEy880j5P/bpLMO70VPv5mUrtMJld8Gs1mfiI0aS5+pDS+HElIiIiUqI49LfasGHDaN++PTNmzKBLF9v69gMGDGDMmDE0adKE4cOH51tAV+Zx/DHZsFgsALi6umIYBqdPn85Tf/r0aUJDQwHbZPWLFy+SkZHxp21OnTqVp95qtRITE2NvIyKSX/638FeSU21vRQbd1ZDa1cvmqd8Yl0rPS7blfrMBv+ZP2OsCO72B96MplGn/SqHFKyIiUhgcSkZcXFx4/fXX+eCDDxg+fDh9+/Zl6NChvPvuu8yfPx9XV4dGezmkZs2alC9fnu+//z5P+c8//0y5cuW444478PDwYM2aNfa6pKQktmzZQsuWLQHbUsA5OTn2Ce0A0dHRHD58OE+b2NhYdu/ebW+zefNmUlJS7G1ERPLD2QvJvPHxZgDc3MxMGdUuT32GFSoeWogPth/C7HMrS5VqtxV2mCIiIoXub2URzZs3p3nz5vbzKzPy85PZbGbs2LFMmDCBKVOm0LVrVzZu3MgXX3zBc889h6+vL/fffz9z5szBbDYTEhLC/Pnz8fX1pW/fvoDt7UrXrl2ZPHkyKSkp+Pv7M2vWLMLDw+nUqRNgm4cSERHB6NGjefLJJ7FYLMyYMYN27dpRv379fH8uEbl5vbTgF9IzbG93h/W5hdAqpfPUr7qQwiOn/2c/jwu9E7NJw7FERKTkczgZ+eSTTyhdujRdu3Zl7969jBgxgri4ODp27MjMmTPx9PTMt6B69uyJq6srCxYsYPny5VSsWJHnn3+efv36ATB27FjMZjOLFi0iLS2NyMhIpk+fbp8PArY9UKZNm8bMmTOxWq20atWKSZMm4eLiAtgmu8+bN4+pU6cyefJk3N3d6dixI08//XS+PYeISHRMAm9/vg0ATw9XJo34w0IghkG5tUOonh0DwCncqRrxYGGHKSIiUiQcSkbef/99ZsyYwciRI+natSsvvfQSVquV+++/n+XLlzN37lzGjx+fr4H16NGDHj16XD9oV1fGjx//p5/p7e3N1KlTmTp16g3bBAUFMXv27H8bqojIDT3/5s9kZ9vWWH9kYDMqlfPPU5+xaTotzy4FIBMTn3vW4tEqzQo9ThERkaLg0DiAZcuWcd999zFmzBhiY2PZsWMHDz/8MJMmTWLMmDF89913BR2niEixc+BYLB+u3AWAn487E/57a94Gx7/DY+Mk++lHpnIE17sPF3P+zcMTERFxZg4lIydOnLCvorVx40ZMJhO33WabXBkWFsaFCxcKLkIRkWJqyhs/YbUaAIwd3JKg0t65lZdOwTcDMGGrX0Updpp8ubVh/yKIVEREpGg4lIz4+PjY9+TYuHEjFSpUoGrVqgCcPXuW0qVL/9nlIiI3nR2/n2XJ9/sACAzwYuzgP6zSt+ddyEwEYB/efG0KpFaVFlQIrFHIkYqIiBQdh8YC1KtXj0WLFpGRkcGqVavo3bs3APv27WP+/PnccsstBRqkiEhxM/n13KXFJw67FX/fPyzycfRL++FnpjIYJhNtIwYWVngiIiJOwaE3IxMmTODkyZOMHz+egIAAHnroIcC2GWJGRgaPPvpogQYpIlKcbNxxkm9+PgxAhTK+jBrQNG+DS6cgdicAp3En3uSGl3c5GtboVMiRioiIFC2H3ozUqlWLVatWcfToUcLCwuzL+L788ss0btwYf3//v7iDiMjNwTAMJs3OfSsyeWRbvL3c8zY69pX9cC+2eSS3NbgXFxe3QolRRETEWTi8ZIuPjw8NGzbMU9auXTsAUlNT8fHxydfARESKox+jjvHTlmgAQiqX4r99Gl/b6GhuMrLH5AOYad3g3sIJUERExIk4lIzk5OTw6aefEhUVRVZWFoZhW/3FarWSnp7O/v372bFjR4EGKiLi7AzDYNKc3LciU0bdhrv7H/6YzUrGOLUWE5CECyfxIDSkA6X9KhVusCIiIk7AoWRk7ty5zJs3D19fX3JycnBzc8PFxYWEhATMZjMDBgwo6DhFRJze8tX72bLbtpN6eGgQ99/Z8NpGJ1ZjyskCbEO0DJOJbpFazldERG5ODk1g/+abb+jatStbtmzhP//5D506dSIqKopPPvkEHx8fatasWdBxiog4NYslh6df+9F+/vJjHXF1dbm24VWraO01+eDuXYHawbde205EROQm4FAycvbsWe6++27MZjN169Zl1y7bjsKRkZEMHTqUpUuXFmiQIiLObtHyHRyKjgOgecPK9Opc59pG1hysR78BIAsTB/CiTb3emM3XSVpERERuAg4lI66urnh4eAAQHBzMiRMnsFgsADRq1IhTp04VXIQiIk4uLT2L5+b+ZD+fMa4zJpPp2oZnN2HOuAjAQbzINpm5tX7vQopSRETE+TiUjNSsWZPffvsNsCUjVquVQ4cOAZCQkEBOTk7BRSgi4uTmfLSZs7EpAHRrU5PbmoVct53xh1W0KlRsStlS128rIiJyM3AoGenVqxfz58/ntddew9vbmxYtWvDMM8/w2WefMWfOHGrXrl3QcYqIOKW4hDRmvLsBAJMJnn28MxsuQab1Dw2tOWQcXGY/3Ys3nRr0KcRIRUREnI9DyciAAQMYMWIEp0+fBuCpp57i3LlzTJkyhcTERJ544okCDVJExFlNe2c9ScmZAAzo0ZAnLOVpsxcGHf5Dw/2L8bp0BICjeJLiFkBkra6FHK2IiIhzcXjTwzFjxtiPa9WqxerVqzl27BjVq1fXhociclM6eSaRuR9vAcDdzYWW/+3Cx7YpIXweB9tToLEvYMkk59dnuTJN/TtTaRqHdcPDXX92iojIzc2hNyMAW7duZdasWfbzo0ePMnv2bPvcERGRm82UuT+RmWWbMzfivibMS/UFwMWwLfDxypnLDXfPxyX5JAAH8bStolW/b6HHKyIi4mwcSkbWr1/PkCFD2LBhQ+6FZjOnT5/mgQceYPv27QUWoIiIMzp8IpEPV9qWOffzcaf+gPbsS4fZxx8lfbMX/3eoPz+dvUD0pWSsUS/ar/vSFERg6epUr9S4qEIXERFxGg4lI2+++SZt2rRhyZIl9rL69evz7bff0qZNG+bMmVNgAYqIOKPZH+/BajUAGDe0NbMTPKmXtpdHz72Om2Ghf9yn7N1Zh+SvBtqX892JDydMnrSu1/v6S/+KiIjcZBxKRg4dOsSAAQNwdc07xcTFxYV+/frx+++/F0hwIiLOaNv+WNb9ZhuDVb6MD9XuasXv6TD+zMw87YIs8TQ4Z1vO1wp8ZQrEZDLTvG6vwg5ZRETEKTmUjLi7uxMXF3fdukuXLuVrQCIizsxqtTLzg13282dG3saMWDcqZ55mYOzHAKRjYhfeea7bhB/nTe7UqdaGUr4VCjVmERERZ+VQMtKsWTPmz5/PxYsX85THx8fz9ttv07Rp0wIJTkTE2cz9eAu7Dtl+OFMjuDTe7ZtwIB0eOzsbN2wT1zcQwDumCrzq1YJo92pEuwTytSkQgJb1tLeIiIjIFQ4t7fvoo4/Sp08fOnfuTNOmTSlTpgxxcXFs3boVk8mUZ5UtEZGS6ujJeCbOWmM//9/kHow6bSbAkshD5xcAYAF+MgWAycTxzFjuCn6e1qem42LKxtuzFPWrdyii6EVERJyPQ29GatSowbJly+jQoQP79+/nyy+/ZM+ePbRt25YlS5ZQq1atgo5TRKRIWa1WHnxmJekZtrcf93QMZWOVGpzLhofOL8DPmgLAVvwwfCrar2tz8kVcjGwAmta+CzdXj8IPXkRExEk5vOlh9erVefXVVwsyFhERpzXvk9/4eesJACoEedHnP80ZdBbcrZk8dna2vd2PplL0bDuBTfuWcehUFCYMe52GaImIiOTl8KaHIiI3q+OnE5gwa7X9fMrIpswxqmIx4N64JVTMPgfAHrxJ9ChNo5q3c89tkzCZcv+IrVK2DlXK1S302EVERJyZkhERkb8w5qXvSE2zDbUa0rsRGfXD2GTxAaB/4gp7u3WmABqH3YG7mxeVy9amVf1+9roW9bTjuoiIyB85PExLRORm9NW6g3z90yEAygX5MPOJ22l0wAUAN2sWnZNsb0zSMHMEL+6oe4/92p5tniTHmo2bqwdtGvYv/OBFREScnJIREZEbSEvPYsxL39nPXxnfmVgPL05ZbefDstfjlp0MwH68CCodSvVKje3tvTz8uL/L9EKNWUREpDjRMC0RkRuY/s4GomMSAbj1lmAG3R3BuqTc+kEp39iP95l8aFGvNyaTqZCjFBERKb5u+GZk9+7df+tGDRs2/NfBiIg4iyMn4pjx7q8AuLiYeHNyd0wmE2uvSkbqn/kCACtw2DWQnpoXIiIi8rfcMBm59957HfoJn2EYmEwm9u/fn6+BiYgUFcMwGPPSd2Rl5wDwyMDmNAyvgNWAny4nI/XSD+GbEg3ACTxo0XQE/j5liyhiERGR4umGyci0adMKMw4REafx7c+H+W79EQAqlPHl+UfaAbAvDWJtex4y+vwce/sj7mXpdMt/CztMERGRYu+GyUivXr0KMw4REaeQlWXh8enf289njOuEv68nAOsuXS40rNx24TN7m7KNH8bD3acwwxQRESkRHF5Ny2KxcOTIEbKysuxlVquV9PR0tmzZwqOPPlogAYqIFKY3Pt7C4RPxADRvWJn778qdD3dlvkij2M+omRMHQLLZgwYtxhd6nCIiIiWBQ8nI7t27eeSRR7hw4cJ1681ms5IRESn2zl9M4YW3frafz3m6G2azbdHBHAN+TgLP7DiGnngOt8ttLFU74uLidp27iYiIyF9xKBmZM2cOFouFJ554gp9++glPT09uu+021q5dS1RUFJ988klBxykiUuCembOWSymZADxwdwTNI6rY63amQqLFSo+jT9DYctZeXqrhg4Uep4iISEnh0D4ju3fv5uGHH2bo0KF0796drKwsBg4cyMKFC2nZsiUffvhhQccpIlKgdvx+loXLtgPg4+3GtLEd89SvS4LIs+9QLfFn6pIGgGF2wxTSudBjFRERKSkcSkbS09OpUaMGAKGhoRw8eNBe16dPH7Zv314w0YmIFJJJs3/EMC4fP9SW31z96XcQlsWBYcCv0dtocWoWgVgojW3JX1OlVuDuV4RRi4iIFG8ODdMKCgoiPt42oTM4OJjExETi4+MJDAykVKlSxMXFFWiQIiIF6dftJ+1L+VYu78eQgS2osQfSrLAkDjp4JVJ152OYySGUjNwLK7UqoohFRERKBofejDRv3px3332Xs2fPUrFiRYKCgvjqq68A+OmnnwgMDCzQIEVECtLk19faj58Z0ZavU9xIs+bWpx98G98s2zyR4KvfhFRsUVghioiIlEgOJSOjRo0iJiaGxx9/HIBBgwYxbdo0br31Vj788EPuuOOOAg1SRKSgrN10jHWbowEIqVyKob0j+eCqhQMrmZKpd+H/AMgxuVLPy/eqSiUjIiIi/4ZDw7SqVavG999/z/79+wF46KGHMJvN/Pbbb0RGRjJs2LACDVJEpCAYhsEzc3LfikwZdRunrK5sSLad1/SEudbP+SonBYD4MrdTPvYtALK8q+LuXa7QYxYRESlJHHozsnXrVtzc3GjVKnd89LBhw1iwYAH33Xcfq1atKrAARUQKyne/HCZq52kAwkKCuP/Ohnx41VuRQUHZbNj5vv18TqNmmKwWANJLRRRmqCIiIiWSQ8nIAw88wOHDh69b9/vvv/PUU0/la1AiIgXNarXmeSvy/Oh2mF1c+DA2t03TS9+TkHwGgNrBramQcc5ep2RERETk37vhMK2nnnqKixcvArahDDNmzMDP79olLI8cOUJAQEDBRSgiUgAWf7mbHfttyUX9WuW4t1s91l+CaNueh7TzM9i9+117+45N/gu75tjP00s3KsxwRURESqQbJiNNmzZl7ty5AJhMJk6fPo27u3ueNi4uLgQGBmrOiIgUK6lpWTw9+0f7+f/Gd8ZsNvPBVW9FehubOHhhHwCVyoRTu2pr+P4+AKxmTzL8wgo1ZhERkZLohslI79696d27NwC1a9fm9ddfp3HjxoUWGEBWVhZ33303ERERTJ8+HbC9pZk/fz6fffYZCQkJNG7cmGeeeca+KeOV62bOnMk333xDWloabdq0YdKkSZQvX97eJikpiWnTprFu3TqsVitdunThqaeewtfX95o4RKRkmfneRmLOJ8NttxDQtQXvlivLhhPwue1lMD5mMI68Y2/fofGDmFJiIMU2ZCsjoB6Y3YoidBERkRLFoTkjBw4csCciFouF5OTkAg3qirlz53Ls2LE8ZW+++Sbz5s1j6NChzJo1i+TkZAYPHpwnpilTprBy5UrGjRvHtGnTOHDgAMOHDycnJ8fe5pFHHmHLli0899xzPP3006xdu5Zx48YVynOJSNGJOX+J/y38FSqVhfvvIKlcWZbHw8sxkHJ5b5F+GV9x6MQvAAT4lKdJ7R5wNsp+j/TSmi8iIiKSHxxa2hdsCcmMGTPYunUrOTk5uLi40Lx5c8aNG0fdunXzPbDff/+djz76iNKlS9vLUlJSWLhwIaNHj+aBBx4AoEmTJrRv356lS5cyZMgQTp48yYoVK3j11Vfp3r07YHuz07VrV3788Ue6dOnCpk2b2Lx5M0uWLCEiwvaPigoVKjB48GD27dtHvXr18v15RMQ5TJr9I2np2fBgRzBf+/MYn8yz+P8+hezL53e2Hoerizuc3WRvk16qUeEEKyIiUsI59GbkyJEj9O/fn71793LHHXfw4IMP0rVrV3bt2sWAAQM4cuRIvgZlsVh4+umnefDBB/MMrdq1axdpaWl07NjRXhYQEECzZs1Yv349AJs22f7B0K5dO3ubkJAQatWqZW8TFRVFUFCQPREB2y7zvr6+9jYiUvJs33eGD1bsghpVILI2AOXcYHtDWB4O04OtjDs/geysSwBE1Lyd5nV72S4+c9WbEa2kJSIiki8cejMyZ84cypUrxyeffEJgYKC9PD4+ngEDBjB37lxmz56db0G98847ZGdnM3z4cFavXm0vj46OBqBq1ap52lepUoW1a21LdB4/fpwyZcrg7e19TZsr1x8/fpzg4OA89WazmcqVK9vb/BNHjhzBfJ2ftBal9PR0APuGleL81GcF57GXbUOvuKeTvWyY6zk8TyVQG8iM/pINZzcC4OVeiluCB3HgwAFMOVmEnd+GGcjyqkSy4Qvp6eqjYkS/r4of9ZnzUx8VP0XRZ1ar9U/rHfqX85YtWxg5cmSeRAQgMDCQhx56iM2bN//zCP/g6NGjzJ8/nxdffPGa1btSUlJwd3e/ptzHx4eUFNsOyampqfj4+Fxz37/bRkRKlp0HL7J++1moXxPCQwCobM6ir0cCADHxe4g69IG9fYcGj+Llblu23OPSfsxW28AtDdESERHJPw69GbFYLHnmblytdOnSpKam5kswVquVSZMm0adPHyIjI6+pNwwDk8l03WuvlN+ozdXlhmFc9w3GjcodVbNmTTw8PP7x9QXhSuZbp06dIo5EHKU+KxhjXvkQTCa4J3eY5/Qa7jQoE84PW+bzzdbZGIbtpze3NhxAt7aDci/evNJ+GFC7C15eXoD6qDjR76viR33m/NRHxU9R9FlmZiZ79+69Yb1D//KuUaMGa9asuW7d6tWrCQkJ+UfB/dFHH33EmTNnGDNmDBaLBYvFAtiSBIvFgp+fH1lZWWRnZ+e5LjU11b4ho6+v73WTo7S0NIfaaGlfkZLnl63RrIk6Bi0aQHBFABp4w53ecbz1xVC+3jjLnojUrNKMXm0n5l5sWGHvwtzzap0LM3QREZESzaFkZNCgQXz++edMmTKFnTt3cubMGXbu3Mmzzz7L8uXL6devX74Es2bNGs6fP0+zZs2oV68e9erV48CBA6xYsYJ69erh6uqKYRicPn06z3WnT58mNDQUsE1Wv3jxIhkZGX/a5tSpU3nqrVYrMTEx9jYiUjIYhsGzb6wDX2/od7u9fGrlTN5YOpADJzbYy7o0G8kj93yIh9tVc85O/AiJlxfpqNwGgvJ/9UAREZGblUPDtO6880727NnDRx99xJIlS/LUDRw4kIEDB+ZLMM8///w1byzGjx9PaGgoo0aNIjQ0lJdeeok1a9bYd31PSkpiy5YtjB49GoCWLVuSk5PD2rVr7Uv7RkdHc/jw4TxtFixYwO7du2nYsCEAmzdvJiUlhZYtW+bLs4iIc1i3+Tg/bz0B/+0Nfra5YneWBpfD8zgXb0syfL1K80DXmdQNue3aG+yen3scMaIwQhYREblpOLzPyNNPP82AAQPYtGkTiYmJlCpVihYtWuTbEC2A6tWrX1Pm6elJqVKlaNCgAQD3338/c+bMwWw2ExISwvz58/H19aVv374ABAcH07VrVyZPnkxKSgr+/v7MmjWL8PBwOnWyraDTokULIiIiGD16NE8++SQWi4UZM2bQrl076tevn2/PIyJFy2LJ4enXfoSGtaCl7QcP/i7wQqnDvPfDAgDMJhdG9X6fquWus79Qyhk4cnm+iFcZqHVPYYUuIiJyU3AoGZk7dy59+vQhJCTkmuTj1KlTvP/++0yePLkg4rvG2LFjMZvNLFq0iLS0NCIjI5k+fbp9PgjAtGnTmDZtGjNnzsRqtdKqVSsmTZqEi4sLYJvsPm/ePKZOncrkyZNxd3enY8eOPP3004XyDCJSOCbNXsvmQ7Hwwih72YxgK+t+mUzO5dWx2jcecv1EBGDPQjBybMf1h4Krcy1QISIiUtw5lIy8+eabtG7dmgoVKlxTt3v3bpYsWVJgycjKlSvznLu6ujJ+/HjGjx9/w2u8vb2ZOnUqU6dOvWGboKCgfN0bRUScy+ff7+N/C3+F+++AINsSvW39oX7sEj498xsAgf6V6d5yzPVvYLXA7rdzzxsOL+iQRUREbjo3TEbuu+8++/JfhmHwn//857pL5mZlZVGrVq2Ci1BE5G/ad/gCQyatgG63QvumAHiaYU7Fi3z82f/s7fp1eD7vZPWrHfsWUi4vllGtC5SqUcBRi4iI3HxumIxMmDCBJUuWYBgGK1asoEWLFgQFBeVpYzab8ff3p0+fPgUeqIiII5KSM+j1yKektmwMfXJ3Wn+lGsQcXEx65iUAGod1p15ou+vfxDBg55u55xEjCy5gERGRm9gNk5HIyEj7xoMxMTE88cQTegMiIk5v1NRvOBwcAgO62cueqwqjK8IrP623l93V+sZDPdn5Fpz4wXbsWwlq9CigaEVERG5uDs0Z+eijjwo6DhGRf23pqn18fDILRve2lz1ZCZ6tAqkZiZw8txuAcqVDKVMq+Po3OfUz/PRY7nmb6WB2eOFBERER+Rsc2vRQRMTZnYtNZvir62DI3WC2zW8bXQGmVwOTCQ6djMLAAKB2tVuvf5NLJ+GrvrbJ6wCRY6DuoMIIX0RE5KakZEREij3DMPjvs1+R0Pt28LNNSO9eymBOqC0RAdh/1U7rtYNbX3uTjERY2QvSY23nVdvBbTMLNnAREZGbnJIRESn2Fi3bwTemANvmhkCQi5VFNU1XXpBgGAYHTtqSEbPZlVpVmudebFht+4ksCoML221lfsHQYwm4uBXmY4iIiNx0NBBaRIq1fYcv8MiiLfDEg/ayRbXMlHfPbRObeIL4SzEAhFaMxMvj8iap57fBmpFwbmtuY3c/uHsFeJcthOhFRERubkpGRKTYSkrOoNeYz0gf0As8bG8x/lsO7grM227/idxVtGoHtwZLJmx6AbbMyN1hHaDG3dD+NQgILYzwRUREbnpKRkSkWLJarQx+agWHs8xQowoAoe4Gr4VeuznrwZO/2o8j/ALh4yZwcW9ug9K1oP3rENq1wOMWERGRXEpGRKRYmvHur6z48QDc3speNrKiCV+XvO1ycrI5dHIjNYx0OplSqbhqkG2eCIDJBZpNhBaTwdWjEKMXERERUDIiIsXQ6l+P8syctbaThrmbsXYv/YeGOVlc3DSDMZmHCCaTyyv72gTVg67vQ4UmBR2uiIiI3ICSEREpVk7EJNJ//FKsVgM8PTCHVcMKVHWHul6QkHyW1b+8RHjCbuok7qV8ZkLeG3iVse0f0vRJvQ0REREpYkpGRKTYyMjM5p5HPyMuMR2Ahr1asttsW6G8e2k4H3+Erz/vzf2pe/HM8xoEYnDHv81L+DUeDa6ehR67iIiIXEv7jIhIsTF66rds23cWgOCKATS4J3fzwlaWHbz5WV96p+63JyJWYA/evG6qyDulWuHXbLwSERERESeiNyMiUiy8s2QbC5ftAMDD3YVlr/fj7nTbcr7Vk35hx7ZR9M46SSAWAFJL12ZDpa5sPb+f1IwE+rZ5oshiFxERketTMiIiTu9wdByPvPSt/fytZ+/ALbQSZ3aBa04aXY48Rmh2HG24BIDh4olPry+5vXQtbi+qoEVEROQvaZiWiDg1q9XKsGe/JDPLtjnhg/dEMvSexnx7eV56tcSf8cpOZIARa7/GdOuLtr1DRERExKkpGRERp7Zw6Q5+3noCgCoV/HntKdvGhFeSkeoJP3CXEU+Zy8OzqNgCGj9WBJGKiIjI36VkRESc1pkLl3hi5g/283nP3oGfjwcJFtiYDGZrJhEJq2hLEgCGiwfcvgjMLje6pYiIiDgRzRkREaf1yIvfkZScCUCfOyMwNwrnhVOwNsm2Ula1pI20zLlg/6mKqdFoCKpTZPGKiIjI36NkRESc0pLv9rJ89X4wm/G+vTnr7unM0v1521RPWEVTIzm3oP7gQo1RRERE/h0lIyLidA4ci+XBZ76EhrWgbxfSKpUlLSdvGz+ThQ7xX1OVLACsZRpgLlO/CKIVERGRf0rJiIg4leTUTHo98hkprSKhfzd7uYclibvcjtIjtCFN/V3h4lZOb4yx15vr/acowhUREZF/QcmIiDgNwzAYOmklB6zu0LeLvbxT+loaHHiCrKwkYk9EUuGOOaw+/D2dsQ3RMjBjqj2gqMIWERGRf0jJiIg4jVnvR7H056Mw5SFwdcFszWZkwqtw5F0shkEpcjh+ZjvTF99N9ZwkSmMbu2Wt2g4X34pFHL2IiIj8XUpGRMQp/LTlOE++uhqG9oZygQSmHaTHiWfg0g58jRxGG2eoQhYH8WJJejYRRqL9WhdNXBcRESmWlIyISJE7fS6Jex//HGuLCPwiA2l29AnCL67AhIG7YWWEcY4qlyeqh5POU8YpDEwA5Jg9cKnZqyjDFxERkX9IyYiIFKnMLAt9H/uchHKlaNl+PxG7nsLFyAbAbBg85JJIiCUjzzW2P7gM2//W6gnuvoUas4iIiOQPJSMiUqTGTl/FKdNx7uu0kYALp+zlnm4+PB7gReULx2wFbr7Q62s49jVsnw1WCwCu9R8sgqhFREQkPygZEZEis3DZZn6Pe4eezfZyeRQWhsmN2xoN4m73bDyinrMVmt3g7i+g6m22X/UGw2+vQukwqNapqMIXERGRf0nJiIgUiXWbj/PRz9OpH7rXXpbiH8HkO6dRwxX4sGFu424f5k06ytSDrosKL1gREREpEEpGRKTQHTgWy6DZn3NXs98BsJjcia4+nsW3/4cy7iZY0h5yMm2NG42G2vcVYbQiIiJSUMxFHYCI3Fxi41Np//JPNOx0BPPlfUKiqw5jUdehlPFwgd1vw+lfbI39qkKbl4swWhERESlISkZEpNAkp2Zy66tRmHpVpfqltQBkuQXx9u3DqOQOXDoFvzyZe0HnBeDuVzTBioiISIFTMiIihSI5NZPmL/3Modvb0yrmFXt539ZjCPb1hZQz8N0gyEq2VdQdBKHdiihaERERKQyaMyIiBe5SSgatn13N/ju7UjPpeyqk7gKgbKlQOtTrBb/Ngo1TIDvFdoFXWWj3WhFGLCIiIoVByYiIFKhLKRm0nfgte+/uhrtLOi1OzbTX9Wt0Hy7/1wzi9uVe4O4P3ReDV1ARRCsiIiKFScmIiBSYc7HJdBy/kt/vvQuzlwvdDg4jINO2sWGjcuGEb34WUs/kXlDvP9BmBviUL6KIRUREpDApGRGRAnHo+EW6jPiEEw/0hlJ+tD/2JFUubQKgvLs3g1P3YrqSiJQOh9sXQuXWRRixiIiIFDYlIyKS7zbvOs0dIz4m7o72EFqZJqffoPbFLwDwN5t50j0V10snbY1L1YR+P4FPhaILWERERIqEVtMSkXz1zU+H6DDkA+LCa0KHZlSPX0XzmDkAlDGyecbbgselY7bGvlWg7xolIiIiIjcpvRkRkXyzaNl2hk/5ipxyQfDAnZgMCy1P2ZbxvcVIZpD5Eq6XMmyNvcraEhH/akUYsYiIiBQlJSMi8q8ZhsFL839h8uvrwNUFRvQFT3dqXVxJmfRj3GtcpBXJXN5wHQJC4e4VEBhelGGLiIhIEVMyIiL/imEYPDlzNTMXbbQVdGkJVcpjMnJoefYt+hhxtkTkivB+tp3VPQKKJmARERFxGkpGRORfefb1dbmJSFAAbr3akw3UiP+euqn7aMUlAAwXD0wd5kKDB8FkKrqARURExGloAruI/GMvL/iFF+f/Yj9vOOU/ZJtdwLBy+7k36WtctP8hY2o5BRr+V4mIiIiI2DllMpKTk8N7771Ht27daNSoEd27d2fx4sUYhgHYhoXMmzePdu3aERERwZAhQzh69Giee2RlZfHyyy/TunVrIiMjGTNmDOfPn8/TJikpiYkTJ9K8eXOaNm3KpEmTSElJKbTnFCnOZr2/kUmz19rPhz53L7t9AgGIuLSGFsm/EUomAEapWnDL2CKJU0RERJyXUyYjb731FrNmzeKuu+5i3rx5dOvWjZdffpl3330XgDfffJN58+YxdOhQZs2aRXJyMoMHDyY5OXdc+pQpU1i5ciXjxo1j2rRpHDhwgOHDh5OTk2Nv88gjj7Blyxaee+45nn76adauXcu4ceMK/XlFihPDMHhm9o+Mm/GDvWzymI78VLPulQbcffY17jbi7PWmDq+Dq0dhhyoiIiJOzunmjFitVt577z0efPBBRo4cCUDLli2Jj49n0aJF9O/fn4ULFzJ69GgeeOABAJo0aUL79u1ZunQpQ4YM4eTJk6xYsYJXX32V7t27A1C7dm26du3Kjz/+SJcuXdi0aRObN29myZIlREREAFChQgUGDx7Mvn37qFevXtF8ASJOLDs7h+FTvuL9L3baCqqUp9mI7rwbHMxZ20sQumWsoUPCRvywAmDUuAtTaNeiCVhEREScmtO9GUlOTqZnz5506dIlT3loaCjx8fFs2rSJtLQ0OnbsaK8LCAigWbNmrF+/HoBNmzYB0K5dO3ubkJAQatWqZW8TFRVFUFCQPREBaN68Ob6+vvY2IpIrJTWTu0Z9YktEPNzh0YHw/Ei2VKzG2WzbPBBXrHSMfok2lyetW83umNrPLrqgRURExKk53ZuRgIAAnn322WvK161bR4UKFezzPqpWrZqnvkqVKqxdaxu/fvz4ccqUKYO3t/c1baKjo+1tgoOD89SbzWYqV65sb/N3HTlyBLPZufK79PR0APbv31/EkYijnLHPklKyGPHiL+w6FAfubvDYQAjL3azQBYNb3VLolbiU+ok77T/liA/5D7FnMuCM8zxLfnDGPpI/pz4rftRnzk99VPwURZ9ZrdY/rXeufznfwOeff87GjRv573//S0pKCu7u7ri7u+dp4+PjY598npqaio+PzzX3+bttRAQuJmYwePJaWyLi5or50QH2RMSXHCZ4nWddwGHe9D5B0tGFtLy8p4jV5EJCyP1FGbqIiIg4Oad7M/JHX375JVOmTOH222/n/vvvZ8GCBZhusDTolXLDMK7b5upywzCu+xbjRuWOqFmzJh4ezjVJ90rmW6dOnSKORBzlTH128kwiPcd+xKETSeDliduoe8muHQqArxl+qOdCS7/yQHmi9i2ldtpBvC/PFTHV7k+tyLZFGH3BcaY+Eseoz4of9ZnzUx8VP0XRZ5mZmezdu/eG9U6djLz//vtMnz6dDh06MHPmTEwmE35+fmRlZZGdnY2bm5u9bWpqKn5+fgD4+vqSmpp6zf3S0tLytImNjb1uG19f3wJ6IpHiY8fvZ7nrkU85HVgWHmoPkbXJdrP9keFthm/qQEvbbycsOVl8H/U6DxtJ9utNjR8tirBFRESkGHHaYVqzZs1i2rRp3H333bz++uv2YVnVqlXDMAxOnz6dp/3p06cJDbX9xDYkJISLFy+SkZHxp21OnTqVp95qtRITE2NvI3KzWvLdXlo8+wOnHx4Ej98PzerD5UTE0wxf1YG2Abntf9gyn/KXDlOebFtBpVZQoUkRRC4iIiLFiVMmIx988AELFizggQceYPr06bi65r7AiYyMxMPDgzVr1tjLkpKS2LJlCy1btgRsSwHn5OTYJ7QDREdHc/jw4TxtYmNj2b17t73N5s2bSUlJsbcRudlYrVaefONn+m1PJ2vsf6BiGXtdKRcYUR62NYQOf0hEvt30Ou2veiuC3oqIiIiIA5xumNaFCxeYOXMmYWFh3HHHHezatStPff369bn//vuZM2cOZrOZkJAQ5s+fj6+vL3379gUgODiYrl27MnnyZFJSUvD392fWrFmEh4fTqVMnAFq0aEFERASjR4/mySefxGKxMGPGDNq1a0f9+vUL/blFitrOwxfo+9lBjkQ0gqDL2YZh0NI4Qh/relzP/szJ33byhV9lztTtTbM6Pdm49zO+3vga5Y0s6mBboQPfKlCzV5E9h4iIiBQfTpeMbNiwgaysLA4dOkS/fv2uqY+KimLs2LGYzWYWLVpEWloakZGRTJ8+3T4fBGDatGlMmzaNmTNnYrVaadWqFZMmTcLFxQWwTXafN28eU6dOZfLkybi7u9OxY0eefvrpQntWEWcQm5bNgK+iWeNXHjq0sZd7ZScx8vQjZF7YyLGr2p+NO8SK9dP5csMrWI0cAG41LuU2iBwNLm6IiIiI/BWnS0Z69+5N7969/7Ld+PHjGT9+/A3rvb29mTp1KlOnTr1hm6CgIGbPnv1PwhQpEb7YfJJ+sQFkV62VpzwyJ4n+sY9x4sLGPOVeHn6kZ15euvdyIoJh0NzTDTIAkxnqP1gYoYuIiEgJ4HTJiIgUvPjENJ6YuZpF1epDvdwJIDXiY3mraQAXd89g46n1AHi6+9K56UPUC7mNSmVrcy7uCJv2LWXL/hWkZV6iX+QgvLc+Y7tBxRbgXeZ6HykiIiJyDSUjIjeZpav2MWrqt1xo3hjq1QDANS2dxeVT6NeqLN9vfouNe5cAYDa7MuzOtwgPbmW/vlKZMHrf9jQ920wg25KBx96FuTcP7VaozyIiIiLFm5IRkZvEhbgURk39lqWrfodawdCrvb1uRYQb4ZnRfPDddLYeWGkvH9h5Wp5E5Gpmswse7j4Q/X1uoZIRERER+RuUjIjcBJZ8t5dRU7/l4qUMqF4FhvcBs21l73HGN2z/9nW+iz+a55q7mz5E89QjsHYMNHsKfCtee+PsdDi1znbsXQ7KRRb0o4iIiEgJomREpAS7lJLBwy9+x8dJbjC0D9SoAh7u9vrbs6PI2P4oV28PWsrNk/+UC6bmzpchM9FWePpn6L8R3HzyfsDpn8Fy+eqQ220T2EVEREQcpGREpISK2nGK3m9u4lyXtlCl/DX1FVyyaHZwCvFAoJFNa/8gbvH0ICjhd0yn9uVtHLsbVv0X7vg/MJlyy68eohXStWAeREREREosJSMiJczFhFSeeSeKt13LYQztm6eunJtBW38TbfyhSvRC9iUc4DEjlppkQNJJSLq6tQnC7oFj34IlDQ5+ChWaQpOxuU2Of5fbtlqXgn40ERERKWGUjIiUEOkZ2bz+0WZeei+K5IcHYA6tgL8lEb+cZBqSwJTqHjStXB2TqxtxiSdZv/l5JhgXcMfIeyM3H9sO6s0nQVBtOPApfNPfVvfLE1CuEQR3gMRjkHDIVl6xmZb0FRERkb9NyYhIMZeRmc3CpTuY9s56Yi6kUHpYJ2aZZzJ8y9v4WNNyG24HzK5QOgySz9EzJz63zr8a1B0E1Trb9gpxyZ1XQu374Pw2+G0mGFZYcTe0eh7MLrltNERLRERE/gElIyLFVGaWhUVLNjPn/Z+IuZCCCXikXwrPme4k8GzC9S+yWiDud4KuKsqu/yBu7WeDu++NP6zNNLiwA07+CNkp8PO4vJPVtaSviIiI/ANKRkSKoW9/PsRPi19kavgnjOxmyVuZY/s/i8mVaJMnaVYrmZhxw6ACWZQlGxcgHlfON3mKOre98NcfaHaFu5bDusdg33u2MsNq+3/PICjfJL8eTURERG4iSkZEipGDxy8ybsYqNm/dzZEBK/DAct12OzyqsiLLRBxucPkFhpeHP64ubphyLPgb2VQLu5P72j7v+Id7+EPXRVB/KPw4Ei7utZVXvyPvkC0RERERBykZEXFy2dk5fLnuIAs++43VG48B8PqgowSQDMBhz5qccauECYMLbuU44luZ06e/ARO4urgRUfN2WtbrS1hwS8z5sQ9IlVvh/u2wdyHE/W7bEFFERETkH1AyIuKkUlIzeeuTrbz2wSbOXUyxl4e1DGCE50owIAszy8p3we+W58nxLINL3FZi1gwEwGQyM7r3B9Ss0iz/g3Nxg4gR+X9fERERuakoGRFxMmkZFj75/gjvf/cdcQGloEEdSE2Hc3GUL+PNK62X4pZoG561Fn9On1qF94VN3Nl6LD9snY9xeS7H7c0eLphERERERCSfKBkRcRKGYfDJt3sZtiGWtHrN4MW7wDXvXIzwpJ+56/cvAbiEC6tNpQFIy0zis7VT7O1CK0bSrcXowgteRERE5B9QMiLiBI6ciOOhl75nbYPG3Nk6hbvjnyXoSBxBljhKWxKwmsxkmdypmnXKfs03ptKYPPxoWLUVu4+utpd7uvsyuNtruJj121tEREScm/61IlKEkpIz+N/CX5m5ZAdZI/oxxmc5cw4+9pfXncWNKPy5p/U4bmv0ALuPrmbpTy+Smp7IA11fISigSsEHLyIiIvIvKRkRKQJZWRYWLNnG8/N+Jq5sORg/mLvdN/DawcevaXt52xCuDNhKw8wnprIEV2xEm4a2yeoNa3SmQfVOWHKycHP1KJyHEBEREfmXlIyIFKL0jGze/2InL6/cx+kaNWDiQxAUQNPkLfzf7wMwYwCwlgB+MgWQiguZmMBkwmQYuGJgwYTJ7MqETi9hvmp/D5PJpEREREREihUlIyKFIPFSum2Z3qU7udi2OYx+AMxmzEYObZJ+4rPD/fC2pgOwHR9WmMoSWKoqIf5V8Pcpw6kLv3Mu/gjZmADo3GQYlcvWLspHEhEREfnXlIyIFKAzFy4x+4NNzFvyGymR9WH8g+DnQ8vkjfznwgf0TFhB+ewL9vbH8OAjUzk6RDxOz44P57nXpdSLHI3ZCkBErdsL9TlERERECoKSEZF8lpNjZd3m4yz+ajeffLOXLKsBw/tAk7q4WzOZHv04j5+dfc1153DjbVNFbgkbTHil9tfU+/uUITKsWyE8gYiIiEjhUDIikg8slhx+3X6K5Wv289l3ezl/MdVW4WK2JyK10g/x6eH7aJy6w35dNnAAb3aZfNiOL80i7qdhxT5F8xAiIiIihUzJiMg/lJll4eufDvHFmv18+8thEpIywNcb0jNsDVzMuIzsS05kHXrEf8Unh/vja7UlKRbga1MgGwggw2QGoEW9PvRt/yyHDh4uoicSERERKVxKRkT+BsMw2LonhvdX7OLjbWe4VLUKBFeH0c2hYlnw8gCrgWd6OgGeLpx38aBe2l4+O9QPb8M2QT0WV94zlScjsA6tq3ekRuVbCK3YGD/voCJ+OhEREZHCpWRE5C8YhsH238/yyarfWRydzvngYGjSFjr5Xf8Cs4kMH28yAH9LEl8c6GlPRPbgzUculWnf4hE6N30IVxf3wnsQERERESejZETkBqJjEvho5W7e3nqO07VrwS23QgvPG7av7A41PSHRAiezIDHbyuKj/6FW5lEAzuDOqnJtebz761QMqlVYjyEiIiLitJSMiFwlJTWTpT/8zgcrdvHTlmhoUhceuhfMpjztXA0rrX0NugW50DYA6noaBBgpkJEAGfGQkUDW0W9wj18JQDpmPnQPZdhd7xAUUKUInkxERETE+SgZkZueYRj8svUEi5bvYNnq30lNy7ZVhFSCB3vR6dIabk9cRXDmKRrknCI45xxeJgvmKzewpENmIlgtee579QCsD03laNv+BSUiIiIiIldRMiI3LavVyoo1B5j+7ga27jmTt7K0Py6PDmBs7Gv87+SEf/U5qyiFtXoPWtbr+6/uIyIiIlLSKBmRm0pyaiZRO0+x/reTfL5qHwePx9kqvDwgqBReXm50bl2T/W1acuuFj6+biOS4emOY3TAwwACr2YUsFy8yXTxIM8zEZlwiyZJFmsnMedw56FmZSZ1ewmQyXXMvERERkZuZkhEp0S7EpbB+20nW/3aC9dtOsvPAOaxWI7dBKT/odiumdrdguLqSDnwJ3B2/gneODrM3W0MAm0z+JOBKptUM1qs+JAfb7oV2/lwZw+Xq4saQLtMJ8C1XUI8oIiIiUmwpGZESwzAMjp9OYP22k6zZdYZfTiRzMscFypaGchXgzrpwlwkSLtl+ebhjurURhqsrRu5NuCvhSz491A+XyxnHevxZYQoCB99suLq4UaNyM+qGtKFhjU6ULRVSIM8rIiIiUtwpGZFiy2q1svfwBdb/dpKft59kTbo7CZH1ICQcOjdy6B5XkhBPMzya8zMP7HuUusm77PXb8WGJqQy1Q9pQ2rcCbq6euLt64ebqgZurJ26unni4eeHp4Yenuy/eHv5ULBOGh5t3/j+wiIiISAmjZESKjawsC7/tO8P6306yftsJ1u+/wCVvH6gTCu07Q1AALtYMvLLjcUk/h6uRidmaTZaLL+WtyUSm7aNKdgzeOWn4WFPxyUklMCeO2tnHCEyPJjjrQu4KWcA+vPjSP4IRnV6iXmi7InpqERERkZJLyYg4reTUTDbuOMWGbSf5eedpNqdAVvWqEBaCuWd9SvW5QM30wwSm7SUobjlVT+7j1syDlDGy8cCKB1b8yCGETPzJcfhzE3DhW5cKeEQMZ2LrsXi6+xbgU4qIiIjcvJSMiNO4Mtn8670XWJPmxmkXD6qWSqNxwGHatt9Ld8sFvLNj8Um7gPvvcViwkoUZb3KINFKpQxou/+Lz002uHKnUHrdmT3JvcBvcXD3y7dlERERE5FpKRqTQZGZZOBwdx/5jF/n9aCzbzqYSnWYlNssgIcdEZukAaBROi9rn+Cx6BI0yDuKdlg1p/+5zs02unHMP5KTZlxjDzKWsdDIMK5mY8fQpR1j1TtSt1Z1KVVrRwNX9r28oIiIiIvlCyYjku5TUTA4cv8jvR2L5/dhFdp5N5GjKJeJNGbiX8YQKgVCxDNSsANhWqCoNlM04zpTTj9Dz1O5/9IbD8C6HKexeqNYJPEqBuy+4+eFWqjpVza5UvdLOMMjISiEzOw1/n7KYTeY/u62IiIiIFBAlI/KPxSWksf3IRX4+dYl9F06QkHYQl5yj+LqcxdM1FU9S8HRJpmalNGpedZ1bhpXy0dlUJAt/LHgZVjwxqE8qZbDY213ChRiTJ+k+lTAH1iYgIJhSPmXx8y5j+w/XkgaWdLBaoEpbTFXbgfmv/5M2mUx4efjh5eGX31+JiIiIiPwNSkbkugzDID4xnaMxiXwbc5FdF38lPTuFFKsPyRZfMqwGpT1iKGc9SLnUPVTOuUQtcijvkk0Q2fhZcvAzcvAlB+/Lk8k9seJLDkFY+LN3ERZMHKp4G15tXqZWpVtwddHQKREREZGSSMnITSrLCofTDXZczGTX2RQOxqVzIsVCYkoWKZfSSU5Kxd87lgZlN9Iy8QsGGQl4GlZSTS6kYMaCibJp2ZQzsilPNuXIwi/PtuT/TFpgfTzuWEzdchH58JQiIiIi4syUjJRQVquVC3FpbD6WxO/JJs4fOsrhLDNx1kQyXNPI8nbHZDJws6bjk3Uen6zzBGafo6r5PEFeMVRwiaG25Twt4pMJJz33TYbxZ5/qABd3CKwNQfWgTH3wDwGPAHD3B+9yeJcOc3incxEREREp3pSMlADbDl/g+V/OcCLLxAWTG0nunqT7+UBgKSjdAnNANqEJq2ma+B69k6PwJQd3DNyx4o2VMkY2ZcimDBYCsODxTzIOrzJQOhwCw6FULfCtBN7lbL88S4ObH7j72ZIRJRsiIiIigpKRYs9qtdJ1Wzz3+a/ilux4AnOSCMxJxPPSJVzjU3DPuUSZzFNUsyZThuw/natxw8/wrYK5/hAoFwkZ8ZAeB9mpEBBqSz5Kh4NXYL4/m4iIiIiUbEpGijmL1WD3maZUNFL+9b2sZncMn4qYfSti8qkAPpWgZk/MwR3A/G+2ExQRERERudZNn4wsWbKEd999l3PnzlGnTh0mTpxIZGRkUYflMBcjC3ey/rJdDmayAqrjWaU1Jr9gcPOx/XL3s83bKFUDs28l0J4bIiIiIlJIbupkZMWKFUyZMoVRo0bRoEEDPvroIx588EFWrlxJ1apV//oGTsDFzYukOz7j4I4FpFutpGAmBTNeXkFUDKyBkeFJad9q1GnRGy8tkSsiIiIiTuSmTUYMw+D111/n3nvvZfTo0QC0atWKrl278sEHH/DMM88UcYSOqx7ek+rhPa9bt3//ftuBEhERERERcTI37ZicEydOEBMTQ4cOHexlbm5utGvXjvXr1xdhZCIiIiIiN4eb9s1IdHQ0ANWqVctTXrVqVU6ePElOTg4uLo5N2jYM21K4hw4dwmx2rvwuIyMDgH379hVxJOIo9ZnzUx8VP+qz4kd95vzUR8VPUfSZ1WrbFPvKv5f/6KZNRlJSbKtP+fj45Cn38fHBarWSnp6Or6+vQ/fKzs4GICvrryeSF5Ur//FJ8aE+c37qo+JHfVb8qM+cn/qo+CmKPsvOzsbT0/Oa8ps2GbmSnZn+sAHfjcr/jI+PD2FhYbi5uf2t60RERERESjLDMMjOzr7mBcAVN20y4ufnB0BqaiplypSxl6elpWE2m/H29nb4Xmaz2X4/ERERERHJdb03Ilc41wSHQnRlrsipU6fylJ86dYrQ0FC94RARERERKWA3bTISEhJCxYoVWbNmjb0sOzubn376iZYtWxZhZCIiIiIiN4ebdpiWyWRi2LBhTJ06lYCAABo3bszixYtJSEhg8ODBRR2eiIiIiEiJZzJutM7WTWLRokV8+OGHJCQkUKdOHSZMmEBkZGRRhyUiIiIiUuLd9MmIiIiIiIgUjZt2zoiIiIiIiBQtJSMiIiIiIlIklIyIiIiIiEiRUDIiIiIiIiJFQslIEcnJyeG9996jW7duNGrUiO7du7N48WKurCdgGAbz5s2jXbt2REREMGTIEI4ePZrnHomJiTz33HO0b9+exo0b069fP6KiovK0SUpKYuLEiTRv3pymTZsyadIkUlJS/jI+Rz7/+++/Jzw8/Jpfixcv/pffjvMpCf0F8NFHH9GlSxcaNmzInXfeybfffvsvvhXnU9z76Y033rju76nw8HA6dOiQD9+Qcynu/XXl3s888wy33norzZo1Y+TIkddspluSlIQ+O3HiBCNHjiQyMpIWLVrw9NNPk5CQ8C+/Gefi7P10tQ8++IAePXpcU56VlcXLL79M69atiYyMZMyYMZw/f/5vfhPFR0nosytGjx7NCy+84PgNDSkSr7/+ulG/fn3jrbfeMjZu3Gi8/vrrRp06dYy3337bMAzDeOONN4wGDRoYH3zwgbFmzRrjnnvuMW699Vbj0qVLhmEYhtVqNQYNGmS0adPGWLZsmbF+/Xrj8ccfN2rXrm1s377d/jmDBg0y2rdvb3z77bfG8uXLjRYtWhjDhw//y/j+6vMNwzBmz55tdO7c2dixY0eeX7Gxsfn8bRW9ktBfb7/9tlG3bl1jwYIFxsaNG41nnnnGCA8PN6KiovL52yo6xb2fzp49e83vp2XLlhnh4eHGW2+9VQDfWNEq7v1lGIYxdOhQo2XLlsYXX3xhrF271ujZs6fRvn17IyUlJZ+/LedQ3PssPj7eaN26tdGhQwdj5cqVxo8//mj06dPH6NGjh5GZmVkA31jRcPZ+uuKHH34w6tWrZ9xxxx3X1E2cONFo1qyZsWzZMuO7774zOnfubNx1112GxWL5l9+OcyoJfWa1Wo0ZM2YYYWFhxvPPP+/wPZWMFIGcnBwjMjLSeO211/KUP/fcc0aLFi2M5ORko1GjRsaCBQvsdYmJiUZkZKSxaNEiwzAMY9euXUZYWJixcePGPPft0aOHMWbMGMMwDCMqKsoICwszdu7caW+zceNGIywszNi7d+8N43Pk8w3DMEaOHGk89thj/+xLKEZKQn8lJycbERERxrvvvpvn2oEDBxozZ878m9+IcyoJ/fRHFovF6NWrl3H//fcbVqvV8S+jGCgJ/XXx4kUjLCzM+Pzzz+1tjh07ZoSFhRnffffdP/hWnFtJ6LOFCxca4eHhxpEjR+xt4uLijEaNGhmLFy/+B9+K83H2fjIMW19Nnz7dCA8PN5o2bXrNP2xPnDhh1K5d2/jmm2/sZcePHzfCw8ONVatW/b0vpBgoCX128uRJY/jw4UaDBg2Mhg0b/q1kRMO0ikBycjI9e/akS5cuecpDQ0OJj49n06ZNpKWl0bFjR3tdQEAAzZo1Y/369QCYzWb69u1L48aN7W3MZjPVqlXj9OnTAERFRREUFERERIS9TfPmzfH19bXf53p27dr1l58PcPDgQcLDw//ht1B8lIT+2rBhA5mZmfTt2zfPtYsXL2bcuHF/9ytxSiWhn/7o888/5+DBgzz77LOYTKa/8W04v5LQX5mZmQD4+vra25QqVQqwDYUoaUpCn0VHR1OpUiVq1KhhbxMYGEj16tX/9N7FibP3E8DSpUv56quvmDlz5nWHoG7atAmAdu3a2ctCQkKoVatWiemnq5WEPps2bRqxsbF88sknBAUF/a3nVzJSBAICAnj22WepW7dunvJ169ZRoUIF+5jIqlWr5qmvUqUK0dHRANSvX58XX3wRDw8Pe31KSgpbt26levXqABw/fpzg4OA89zCbzVSuXNl+n+u5Uvdnn5+amkpMTAy///47t99+O/Xq1ePOO+/k559/dug7KE5KQn8dPHiQsmXLsn//fnr16kW9evXo0qULq1atcug7KA5KQj9dLTMzk7lz53LPPfdQq1atG963uCoJ/VWpUiXat2/P/PnzOXr0KHFxcbz44ov4+vpy2223OfQ9FCcloc8qVKhAQkICGRkZ9nqLxcK5c+eIiYn58y+gmHD2fgLo2LEja9asueG8g+PHj1OmTBm8vb1vGGNJUhL67PHHH2fZsmXUq1fvL5/3j5SMOInPP/+cjRs38t///peUlBTc3d1xd3fP08bHx+dPJxk9//zzpKSkMGTIEMCWMPj4+FzT7q/u48jnHzx4EMMwOH36NBMnTmTevHlUrlyZESNG2H+iUZIVt/6Kj48nLS2NsWPH0qdPH959913q16/Po48+yo4dOxx+7uKmuPXT1b755hvi4uIYOnTonz5jSVIc++vK5M/u3bvTqlUrVq9ezdy5c6lQoYJDz1zcFbc+69q1KxaLhSeffJKYmBhiY2N5/vnnuXTpEunp6Q4/d3HjTP0Etn9Ue3p63rD+39y7pChufVarVq1//AZfyYgT+PLLL5kyZQq33347999/P4Zh3LBDr1duGAbPP/88X375JRMnTrRn1je6j2EYmM22rrdYLHl+GbZ5RH/5+TVr1uTtt9/mww8/pH379rRt25Y333yTGjVqMG/evH/0PRQXxbG/LBYLycnJPPHEEwwcOJCWLVsyc+ZMwsLCeOutt/7R9+DsimM/XW3JkiW0bduWkJAQRx+5WCuO/XX+/Hn69euHl5cXr7/+OosWLaJ9+/aMGjWKnTt3/pOvoVgpjn1WvXp1Zs2axZYtW+jQoQNt27bFYrHQoUMHvLy8/tH34OycrZ8c8Wf3LmlDVq+nOPbZv+Fa4J8gf+r9999n+vTpdOjQgZkzZ2IymfDz8yMrK4vs7Gzc3NzsbVNTU/Hz88tzfVZWFk8++STfffcd48aNY9CgQfY6X19fYmNjr/nMtLQ0+xjnP75OmzZtmkOf7+/vf80wBBcXF1q1asXKlSv/4bfh/Iprf1151d2mTRt7vdlspkWLFiVqqNYVxbWfrrh48SI7d+5kxowZ//xLKEaKa38tW7aMS5cu8cUXX1C+fHkAWrVqxX333ccrr7zCxx9//C+/GedVXPsMoHPnznTo0IGTJ08SEBBAYGAggwYNIiAg4N99KU7IGfupd+/efxm3r68vqamp1733H2MsaYprn/0bSkaK0KxZs1iwYAE9e/bkpZdewtXV1h3VqlWzD4EKDQ21t//jeUZGBiNGjGDz5s0899xz9O/fP8/9Q0JC2L59e54yq9VKTEwMd955J2CbkHS1KlWqsG/fvr/8/N9//519+/ZdMyE6IyOD0qVL/9OvxKkV5/6qVq0aANnZ2Xmut1gsJe6nTMW5n67YsGEDLi4ueSYrllTFub/OnTtHhQoV7IkI2H5K2bhxY5YvX/5vvhanVpz7LCYmhqioKPr06WMvs1qtHD58+E/3TSiOnLWfHBESEsLFixfJyMjIMzTo9OnT3HLLLQ7dozgqzn32rzi87pbkq/fff98ICwszXnzxxWuW7ExJSTEaNGhgX1vaMHKXcFu4cKG9bNSoUUbdunXzLH13tSvLte3ateuasj179twwNkc+f+nSpUZYWJixb98+e5v09HTjtttuMyZPnuzgt1B8FPf+urLc6HvvvWdvk52dbXTp0qVELc9c3Pvpiueff97o0aOHYw9djBX3/lq4cKFRt25d4+zZs3mu7d+/v9G7d28HvoHip7j32bZt265ZxvTrr782wsLCjF9//dXBb8H5OXM//dGECROuu7RvWFjYdZf2/f777x2+d3FS3Pvsau3bt/9bS/vqzUgRuHDhgn28/h133MGuXbvy1NevX5/777+fOXPmYDabCQkJYf78+fj6+trfRKxevZrVq1fTs2dPKlWqlGd8sqenJ7Vr16ZFixZEREQwevRonnzySSwWCzNmzKBdu3bUr1//hvH5+Pj85ed37dqVt99+m0cffZTHH38cDw8PFi5cSFpaGiNHjsz/L60IlYT+Cg0N5Z577mHWrFkYhkHNmjX55JNPiImJYc6cOfn/pRWBktBPVxw+fPiatyUlTUnor3vuuYcPPviAYcOG8fDDD+Pr68uKFSvYvn07b775Zv5/aUWsJPRZREQEdevWZdKkSTz++ONcuHCBl19+mbZt29KqVav8/9KKgLP3kyOCg4Pp2rUrkydPJiUlBX9/f2bNmkV4eDidOnX6V/d2RiWhz/4Nk2EUwswUyWP58uU89dRTN6yPiorC39+f2bNn88UXX5CWlkZkZCSTJk2yr40+ceJEvvjii+teX6tWLb7++msA4uLimDp1Kj///DPu7u507NiRp59+Os+6+NdjsVj+9PMBzp49yyuvvGJf//qWW25hwoQJhIWF/d2vxKmVlP6yWCy89dZbLFu2jISEBGrXrs0TTzxB06ZN/+5X4pRKSj8BdO/encaNG/Piiy/+na+gWCkp/RUTE8OMGTPYuHEjhmFQu3ZtxowZQ/Pmzf/uV+L0SkqfnTlzhqlTp7Jlyxa8vb3p3r07jz32WImZwF4c+ulqEydOZO/evfZ7XpGWlsa0adNYtWoVVquVVq1aMWnSpDzDIkuKktJnV3To0IF27drx7LPPOnQ/JSMiIiIiIlIktLSviIiIiIgUCSUjIiIiIiJSJJSMiIiIiIhIkVAyIiIiIiIiRULJiIiIiIiIFAklIyIiUuJp4UgREeekZERERIqN8PBwh9euv+Kv1vAXEZGio2RERERKtLlz5xIbG1vUYYiIyHUoGRERERERkSKhZERERJzS4sWL6dq1Kw0aNODuu+9m27ZteepTUlL43//+Z28TERFB7969Wblypb1NeHg4MTExbNiwgfDwcDZv3gxAWloaM2bMoH379tSvX5/OnTuzYMECcnJyCvUZRURudq5FHYCIiMgfzZ07lzfeeIN7772Xp556ioMHDzJixIg8bUaOHMmhQ4d49NFHCQ0N5eLFiyxatIgJEyZQu3ZtwsPD+fjjj3nssceoVKkSTz75JOHh4WRnZzN06FD7PWvXrs22bduYM2cO0dHRTJs2rYieWkTk5qNkREREnEpKSgpvv/02Xbt2ZerUqQDcdtttlC1blokTJwIQGxuLYRg899xzdOvWzX5tSEgIffr0ISoqivDwcJo0aYK7uzt+fn40adIEsE1o37FjB7Nnz7Zfe9tttxEYGMi0adPo378/DRs2LOSnFhG5OWmYloiIOJWdO3eSmZnJ7bffnqe8R48emM22v7bKli3L4sWL6datG/Hx8ezYsYOVK1fyf//3fwBkZWXd8P6//vorrq6utG/fHovFYv/VtWtXAH755ZcCejIREfkjvRkRERGnkpCQAECZMmXylLu5uREYGGg/X7NmDbNnz+bw4cN4eXlRo0YNatWq9Zf3j4+Px2KxEBERcd368+fP/4voRUTk71AyIiIiTiUoKAjgmuV4rVYrSUlJAGzfvp0xY8Zwxx138OabbxIcHIzJZOLw4cN88cUXf3p/f39/AgICWLhw4XXrS5cunQ9PISIijtAwLRERcSqRkZF4e3vnWRULYO3atWRnZwO2ZCQnJ4cRI0ZQrVo1TCaTvQ3YEpcrrgztuqJVq1YkJSVhMplo0KCB/ZfFYuF///sfR48eLcjHExGRq+jNiIiIOBUvLy/GjRvH1KlTGTduHHfeeScnT57krbfews3NDYBGjRoB8PLLL/PAAw8A8OOPP7J06VIA0tPT7ffz9/fnyJEj/Prrr9StW5eePXvy2Wef8dBDDzFs2DDCwsKIjo7mjTfewNPTU5PXRUQKkckwDKOogxAREfmjFStWsHDhQqKjo6lcuTKPP/44L730Eu3ateOFF15g+fLlvPvuu5w+fRo/Pz9q1arF8OHDmT59Oj4+PnzyyScAfPfdd7z00kskJSUxbdo0evToQUpKCm+88QY//PADsbGxBAYG0rp1a8aMGUPFihWL+MlFRG4eSkZERERERKRIaM6IiIiIiIgUCSUjIiIiIiJSJJSMiIiIiIhIkVAyIiIiIiIiRULJiIiIiIiIFAklIyIiIiIiUiSUjIiIiIiISJFQMiIiIiIiIkXi/wGUwomk1sAJIwAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 921.6x633.6 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Plotting settings\n",
+    "sns.set_style(\"whitegrid\")\n",
+    "plt.style.use('seaborn-poster')\n",
+    "slides_palette_four = [\"#00287f\", \"#00c5ff\",\"#6B8E23\",\"#FF8C00\"]\n",
+    "sns.set_palette(slides_palette_four)\n",
+    "\n",
+    "g1 = sns.lineplot(data=pivot_sth_african_data, x='date', y='cases', hue='value_type');\n",
+    "g1.set_title('SOUTH-AFRICA', weight='bold');\n",
+    "g1.set_xlabel('date');\n",
+    "g1.set_ylabel('total cases per million in 2 weeks');\n",
+    "g1.set_ylim(0,16000)\n",
+    "g1.legend().set_title('');\n",
+    "g1.legend(loc='upper left');"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:capstone] *",
+   "language": "python",
+   "name": "conda-env-capstone-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
I changed the two graphs with our findings based on the comments that we got at our practice presentation. The graphs now only show our model predictions up to October 31st, so the graphs do no longer show the 'strange' predictions for the last four days. I already swapped the figures in our presentation.